### PR TITLE
Empty arrays as parameters are empty lists instead of empty maps now.

### DIFF
--- a/src/ParameterHelper.php
+++ b/src/ParameterHelper.php
@@ -76,7 +76,8 @@ final class ParameterHelper
      */
     private static function emptySequenceToArray($value): ?array
     {
-        if ($value instanceof Sequence && $value->count() === 0) {
+        if (($value instanceof Sequence && $value->count() === 0) ||
+            (is_array($value) && count($value) === 0)) {
             return [];
         }
 
@@ -88,9 +89,7 @@ final class ParameterHelper
      */
     private static function emptyDictionaryToStdClass($value): ?stdClass
     {
-        if (($value instanceof Map && $value->count() === 0) ||
-            (is_array($value) && count($value) === 0)
-        ) {
+        if ($value instanceof Map && $value->count() === 0) {
             return new stdClass();
         }
 

--- a/tests/Unit/ParameterHelperTest.php
+++ b/tests/Unit/ParameterHelperTest.php
@@ -117,23 +117,23 @@ final class ParameterHelperTest extends TestCase
         ]);
     }
 
-    public function testAsParmeterEmptyVector(): void
+    public function testAsParameterEmptyVector(): void
     {
         $result = ParameterHelper::asParameter(new Vector());
         self::assertIsArray($result);
         self::assertCount(0, $result);
     }
 
-    public function testAsParmeterEmptyMap(): void
+    public function testAsParameterEmptyMap(): void
     {
         $result = ParameterHelper::asParameter(new Map());
         self::assertInstanceOf(stdClass::class, $result);
     }
 
-    public function testAsParmeterEmptyArray(): void
+    public function testAsParameterEmptyArray(): void
     {
         $result = ParameterHelper::asParameter([]);
-        self::assertInstanceOf(stdClass::class, $result);
+        self::assertIsArray($result);
     }
 
     public function testStringable(): void


### PR DESCRIPTION
Fixes #43