### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,19 +152,19 @@ If you need lower-level access to the drivers' capabilities, then you want unman
 
 #### Opening a transaction
 
-The `openTransaction` method will start a transaction with the relevant driver.
+The `beginTransaction` method will start a transaction with the relevant driver.
 
 ```php
 use Laudis\Neo4j\Databags\Statement;
 
-$tsx = $client->openTransaction(
+$tsx = $client->beginTransaction(
     // This is an optional set of statements to execute while opening the transaction
     [Statement::create('MERGE (x:Person({email: $email})', ['email' => 'abc@hotmail.com'])],
     'backup' // This is the optional connection alias
 );
 ```
 
-> Note that `openTransaction` only returns the transaction object, not the results of the provided statements.
+> Note that `beginTransaction` only returns the transaction object, not the results of the provided statements.
 
 #### Running statements within a transaction
 


### PR DESCRIPTION
Seems to me that the `openTransaction` should be `beginTransaction` on the client level.
Error: Call to undefined method Laudis\Neo4j\Client::openTransaction()