### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ If you want the results to be just a set of rows, columns, arrays and scalar typ
 use Laudis\Neo4j\ClientBuilder;
 use Laudis\Neo4j\Formatter\BasicFormatter;
 
-$client = ClientBuilder::create()->withFormatter(BasicFormatter::class)->build();
+$client = ClientBuilder::create()->withFormatter(new BasicFormatter())->build();
 
 // Results are a CypherList
 $results = $client->run('MATCH (node:Node) RETURN node, node.id AS id');


### PR DESCRIPTION
The `withFormatter` function requires a `FormatterInterface` object, the example fails. The edit does work. :)

TypeError: Argument 1 passed to Laudis\Neo4j\ClientBuilder::withFormatter() must implement interface Laudis\Neo4j\Contracts\FormatterInterface, string given.