### PR TITLE
Prevent overwrite of existing TCP stream connection

### DIFF
--- a/src/Bolt/BoltConnectionPool.php
+++ b/src/Bolt/BoltConnectionPool.php
@@ -105,7 +105,6 @@ CYPHER
             static function () use ($socket, $authenticate, $connectingTo, $userAgent, $originalBolt) {
                 $bolt = $originalBolt->get();
                 if ($bolt === null) {
-                    $socket->connect();
                     $bolt = new Bolt($socket);
                     $authenticate->authenticateBolt($bolt, $connectingTo, $userAgent);
                 }


### PR DESCRIPTION
Removed `$socket->connect();`

On line 109 the function `authenticateBolt` is called that calls the Bolt function `init`. 
`Init` does the also a `$socket->connect();` and overrides the existing PHP TCP Stream resource.

The lost (overwritten) resource is never closed, resulting in an warning of `a not nicley closed connection`.
`WARN [o.n.b.t.TransportSelectionHandler] Fatal error occurred when initialising pipeline, remote peer unexpectedly closed connection`.