### PR TITLE
Minor README correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ foreach ($results as $result) {
     // Returns a Node
     $node = $result->get('node');
 
-    echo $node->getAttribute('id');
+    echo $node->getProperty('id');
     echo $result->get('id');
 }
 ```


### PR DESCRIPTION
Just a small thing but it tripped me up when trying out this library. Replaced `getAttribute` with `getProperty` in the 'Accessing the results' section of the README. Calling `getAttribute` produces `Call to undefined method Laudis\Neo4j\Types\Node::getAttribute()`.