### PR TITLE
Avoid the failure when neo4j_version is not in the Http response

### DIFF
--- a/src/Http/HttpDriver.php
+++ b/src/Http/HttpDriver.php
@@ -127,7 +127,7 @@ final class HttpDriver implements DriverInterface
 
                 $discovery = HttpHelper::interpretResponse($response);
                 /** @var string|null */
-                $version = $discovery->neo4j_version;
+                $version = $discovery->neo4j_version ?? null;
 
                 if ($version === null) {
                     /** @var string */


### PR DESCRIPTION
* Package version: 2.3.3
* Driver: Http (guzzlehttp/guzzle 7.0)
* Neo4j version: 3.5.25

Avoid the failure when `neo4j_version` is not in the response

`Undefined property: stdClass::$neo4j_version
`