### PR TITLE
Created SSL configuration override at driver level

### DIFF
--- a/src/Bolt/BoltConnectionPool.php
+++ b/src/Bolt/BoltConnectionPool.php
@@ -17,9 +17,6 @@ use function array_flip;
 use Bolt\Bolt;
 use Bolt\connection\StreamSocket;
 use Exception;
-use function explode;
-use const FILTER_VALIDATE_IP;
-use function filter_var;
 use Laudis\Neo4j\Common\BoltConnection;
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
 use Laudis\Neo4j\Contracts\ConnectionInterface;
@@ -28,7 +25,6 @@ use Laudis\Neo4j\Databags\DatabaseInfo;
 use Laudis\Neo4j\Databags\DriverConfiguration;
 use Laudis\Neo4j\Databags\SessionConfiguration;
 use Laudis\Neo4j\Enum\ConnectionProtocol;
-use Laudis\Neo4j\Enum\SslMode;
 use Laudis\Neo4j\Neo4j\RoutingTable;
 use Psr\Http\Message\UriInterface;
 use Throwable;
@@ -44,13 +40,15 @@ final class BoltConnectionPool implements ConnectionPoolInterface
     /** @var array<string, list<BoltConnection>> */
     private static array $connectionCache = [];
     private DriverConfiguration $driverConfig;
+    private SslConfigurator $sslConfigurator;
 
     /**
      * @psalm-external-mutation-free
      */
-    public function __construct(DriverConfiguration $driverConfig)
+    public function __construct(DriverConfiguration $driverConfig, SslConfigurator $sslConfigurator)
     {
         $this->driverConfig = $driverConfig;
+        $this->sslConfigurator = $sslConfigurator;
     }
 
     /**
@@ -100,56 +98,12 @@ final class BoltConnectionPool implements ConnectionPoolInterface
         return $connection;
     }
 
-    private function configureSsl(UriInterface $uri, UriInterface $server, StreamSocket $socket, ?RoutingTable $table): void
-    {
-        $sslMode = $this->driverConfig->getSslConfiguration()->getMode();
-        $sslConfig = '';
-        if ($sslMode === SslMode::FROM_URL()) {
-            $scheme = $uri->getScheme();
-            $explosion = explode('+', $scheme, 2);
-            $sslConfig = $explosion[1] ?? '';
-        } elseif ($sslMode === SslMode::ENABLE()) {
-            $sslConfig = 's';
-        } elseif ($sslMode === SslMode::ENABLE_WITH_SELF_SIGNED()) {
-            $sslConfig = 'ssc';
-        }
-
-        if (str_starts_with($sslConfig, 's')) {
-            // We have to pass a different host when working with ssl on aura.
-            // There is a strange behaviour where if we pass the uri host on a single
-            // instance aura deployment, we need to pass the original uri for the
-            // ssl configuration to be valid.
-            if ($table && count($table->getWithRole()) > 1) {
-                $this->enableSsl($server->getHost(), $sslConfig, $socket);
-            } else {
-                $this->enableSsl($uri->getHost(), $sslConfig, $socket);
-            }
-        }
-    }
-
-    private function enableSsl(string $host, string $sslConfig, StreamSocket $sock): void
-    {
-        $options = [
-            'verify_peer' => $this->driverConfig->getSslConfiguration()->isVerifyPeer(),
-            'peer_name' => $host,
-        ];
-        if (!filter_var($host, FILTER_VALIDATE_IP)) {
-            $options['SNI_enabled'] = true;
-        }
-        if ($sslConfig === 's') {
-            $sock->setSslContextOptions($options);
-        } elseif ($sslConfig === 'ssc') {
-            $options['allow_self_signed'] = true;
-            $sock->setSslContextOptions($options);
-        }
-    }
-
     public function canConnect(UriInterface $uri, AuthenticateInterface $authenticate, ?RoutingTable $table = null, ?UriInterface $server = null): bool
     {
         $connectingTo = $server ?? $uri;
         $socket = new StreamSocket($uri->getHost(), $connectingTo->getPort() ?? 7687);
 
-        $this->configureSsl($uri, $connectingTo, $socket, $table);
+        $this->sslConfigurator->configure($uri, $connectingTo, $socket, $table, $this->driverConfig);
 
         try {
             $bolt = new Bolt($socket);
@@ -172,7 +126,7 @@ final class BoltConnectionPool implements ConnectionPoolInterface
     ): BoltConnection {
         $socket = new StreamSocket($connectingTo->getHost(), $connectingTo->getPort() ?? 7687, $socketTimeout);
 
-        $this->configureSsl($uri, $connectingTo, $socket, $table);
+        $this->sslConfigurator->configure($uri, $connectingTo, $socket, $table, $this->driverConfig);
 
         $bolt = new Bolt($socket);
         $authenticate->authenticateBolt($bolt, $connectingTo, $userAgent);

--- a/src/Bolt/BoltDriver.php
+++ b/src/Bolt/BoltDriver.php
@@ -91,13 +91,14 @@ final class BoltDriver implements DriverInterface
         }
 
         $socketTimeout ??= TransactionConfiguration::DEFAULT_TIMEOUT;
+        $configuration ??= DriverConfiguration::default();
 
         if ($formatter !== null) {
             return new self(
                 $uri,
                 $authenticate ?? Authenticate::fromUrl(),
-                new BoltConnectionPool(),
-                $configuration ?? DriverConfiguration::default(),
+                new BoltConnectionPool($configuration),
+                $configuration,
                 $formatter,
                 $socketTimeout
             );
@@ -106,8 +107,8 @@ final class BoltDriver implements DriverInterface
         return new self(
             $uri,
             $authenticate ?? Authenticate::fromUrl(),
-            new BoltConnectionPool(),
-            $configuration ?? DriverConfiguration::default(),
+            new BoltConnectionPool($configuration),
+            $configuration,
             OGMFormatter::create(),
             $socketTimeout
         );

--- a/src/Bolt/BoltDriver.php
+++ b/src/Bolt/BoltDriver.php
@@ -97,7 +97,7 @@ final class BoltDriver implements DriverInterface
             return new self(
                 $uri,
                 $authenticate ?? Authenticate::fromUrl(),
-                new BoltConnectionPool($configuration),
+                new BoltConnectionPool($configuration, new SslConfigurator()),
                 $configuration,
                 $formatter,
                 $socketTimeout
@@ -107,7 +107,7 @@ final class BoltDriver implements DriverInterface
         return new self(
             $uri,
             $authenticate ?? Authenticate::fromUrl(),
-            new BoltConnectionPool($configuration),
+            new BoltConnectionPool($configuration, new SslConfigurator()),
             $configuration,
             OGMFormatter::create(),
             $socketTimeout

--- a/src/Bolt/SslConfigurator.php
+++ b/src/Bolt/SslConfigurator.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Laudis Neo4j package.
+ *
+ * (c) Laudis technologies <http://laudis.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Bolt;
+
+use Bolt\connection\StreamSocket;
+use function count;
+use function explode;
+use const FILTER_VALIDATE_IP;
+use function filter_var;
+use Laudis\Neo4j\Databags\DriverConfiguration;
+use Laudis\Neo4j\Enum\SslMode;
+use Laudis\Neo4j\Neo4j\RoutingTable;
+use Psr\Http\Message\UriInterface;
+
+final class SslConfigurator
+{
+    public function configure(UriInterface $uri, UriInterface $server, StreamSocket $socket, ?RoutingTable $table, DriverConfiguration $config): void
+    {
+        $sslMode = $config->getSslConfiguration()->getMode();
+        $sslConfig = '';
+        if ($sslMode === SslMode::FROM_URL()) {
+            $scheme = $uri->getScheme();
+            $explosion = explode('+', $scheme, 2);
+            $sslConfig = $explosion[1] ?? '';
+        } elseif ($sslMode === SslMode::ENABLE()) {
+            $sslConfig = 's';
+        } elseif ($sslMode === SslMode::ENABLE_WITH_SELF_SIGNED()) {
+            $sslConfig = 'ssc';
+        }
+
+        if (str_starts_with($sslConfig, 's')) {
+            // We have to pass a different host when working with ssl on aura.
+            // There is a strange behaviour where if we pass the uri host on a single
+            // instance aura deployment, we need to pass the original uri for the
+            // ssl configuration to be valid.
+            if ($table && count($table->getWithRole()) > 1) {
+                $this->enableSsl($server->getHost(), $sslConfig, $socket, $config);
+            } else {
+                $this->enableSsl($uri->getHost(), $sslConfig, $socket, $config);
+            }
+        }
+    }
+
+    private function enableSsl(string $host, string $sslConfig, StreamSocket $sock, DriverConfiguration $config): void
+    {
+        $options = [
+            'verify_peer' => $config->getSslConfiguration()->isVerifyPeer(),
+            'peer_name' => $host,
+        ];
+        if (!filter_var($host, FILTER_VALIDATE_IP)) {
+            $options['SNI_enabled'] = true;
+        }
+        if ($sslConfig === 's') {
+            $sock->setSslContextOptions($options);
+        } elseif ($sslConfig === 'ssc') {
+            $options['allow_self_signed'] = true;
+            $sock->setSslContextOptions($options);
+        }
+    }
+}

--- a/src/Common/BoltConnection.php
+++ b/src/Common/BoltConnection.php
@@ -17,6 +17,7 @@ use Bolt\Bolt;
 use function call_user_func;
 use Laudis\Neo4j\Contracts\ConnectionInterface;
 use Laudis\Neo4j\Databags\DatabaseInfo;
+use Laudis\Neo4j\Databags\DriverConfiguration;
 use Laudis\Neo4j\Enum\AccessMode;
 use Laudis\Neo4j\Enum\ConnectionProtocol;
 use Psr\Http\Message\UriInterface;
@@ -45,6 +46,8 @@ final class BoltConnection implements ConnectionInterface
      * @psalm-readonly
      */
     private $connector;
+    /** @psalm-readonly */
+    private DriverConfiguration $driverConfiguration;
 
     /**
      * @psalm-mutation-free
@@ -58,6 +61,7 @@ final class BoltConnection implements ConnectionInterface
         ConnectionProtocol $protocol,
         AccessMode $accessMode,
         DatabaseInfo $databaseInfo,
+        DriverConfiguration $config,
         $connector
     ) {
         $this->serverAgent = $serverAgent;
@@ -67,6 +71,7 @@ final class BoltConnection implements ConnectionInterface
         $this->accessMode = $accessMode;
         $this->databaseInfo = $databaseInfo;
         $this->connector = $connector;
+        $this->driverConfiguration = $config;
     }
 
     /**
@@ -147,5 +152,13 @@ final class BoltConnection implements ConnectionInterface
     public function close(): void
     {
         $this->bolt = null;
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function getDriverConfiguration(): DriverConfiguration
+    {
+        return $this->driverConfiguration;
     }
 }

--- a/src/Databags/DriverConfiguration.php
+++ b/src/Databags/DriverConfiguration.php
@@ -28,30 +28,29 @@ final class DriverConfiguration
 {
     public const DEFAULT_USER_AGENT = 'neo4j-php-client/%s';
 
-    /** @var string|null */
-    private $userAgent;
+    private ?string $userAgent;
     /** @var pure-callable():(HttpPsrBindings|null)|HttpPsrBindings|null */
     private $httpPsrBindings;
+    private SslConfiguration $sslConfig;
 
     /**
-     * @param string|null                                                 $userAgent
      * @param pure-callable():(HttpPsrBindings|null)|HttpPsrBindings|null $httpPsrBindings
      */
-    public function __construct($userAgent, $httpPsrBindings)
+    public function __construct(?string $userAgent, $httpPsrBindings, SslConfiguration $sslConfig)
     {
         $this->userAgent = $userAgent;
         $this->httpPsrBindings = $httpPsrBindings;
+        $this->sslConfig = $sslConfig;
     }
 
     /**
-     * @pure
-     *
-     * @param string|null                                                 $userAgent
      * @param pure-callable():(HttpPsrBindings|null)|HttpPsrBindings|null $httpPsrBindings
+     *
+     * @pure
      */
-    public static function create($userAgent, $httpPsrBindings): self
+    public static function create(?string $userAgent, $httpPsrBindings, SslConfiguration $sslConfig): self
     {
-        return new self($userAgent, $httpPsrBindings);
+        return new self($userAgent, $httpPsrBindings, $sslConfig);
     }
 
     /**
@@ -62,10 +61,7 @@ final class DriverConfiguration
      */
     public static function default(): self
     {
-        return new self(
-            self::DEFAULT_USER_AGENT,
-            HttpPsrBindings::default()
-        );
+        return new self(self::DEFAULT_USER_AGENT, HttpPsrBindings::default(), SslConfiguration::default());
     }
 
     public function getUserAgent(): string
@@ -91,7 +87,10 @@ final class DriverConfiguration
      */
     public function withUserAgent($userAgent): self
     {
-        return new self($userAgent, $this->httpPsrBindings);
+        $tbr = clone $this;
+        $tbr->userAgent = $userAgent;
+
+        return $tbr;
     }
 
     /**
@@ -101,7 +100,23 @@ final class DriverConfiguration
      */
     public function withHttpPsrBindings($bindings): self
     {
-        return new self($this->userAgent, $bindings);
+        $tbr = clone $this;
+        $tbr->httpPsrBindings = $bindings;
+
+        return $tbr;
+    }
+
+    public function withSslConfiguration(SslConfiguration $config): self
+    {
+        $tbr = clone $this;
+        $tbr->sslConfig = $config;
+
+        return $tbr;
+    }
+
+    public function getSslConfiguration(): SslConfiguration
+    {
+        return $this->sslConfig;
     }
 
     public function getHttpPsrBindings(): HttpPsrBindings

--- a/src/Databags/SslConfiguration.php
+++ b/src/Databags/SslConfiguration.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Laudis Neo4j package.
+ *
+ * (c) Laudis technologies <http://laudis.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Databags;
+
+use Laudis\Neo4j\Enum\SslMode;
+
+/**
+ * @psalm-immutable
+ */
+final class SslConfiguration
+{
+    private SslMode $mode;
+    private bool $verifyPeer;
+
+    public function __construct(SslMode $mode, bool $verifyPeer)
+    {
+        $this->mode = $mode;
+        $this->verifyPeer = $verifyPeer;
+    }
+
+    public function getMode(): SslMode
+    {
+        return $this->mode;
+    }
+
+    public function isVerifyPeer(): bool
+    {
+        return $this->verifyPeer;
+    }
+
+    /**
+     * @pure
+     */
+    public static function create(SslMode $mode, bool $verifyPeer): self
+    {
+        return new self($mode, $verifyPeer);
+    }
+
+    /**
+     * @pure
+     */
+    public static function default(): self
+    {
+        /** @psalm-suppress ImpureMethodCall */
+        return self::create(SslMode::FROM_URL(), true);
+    }
+
+    public function withMode(SslMode $mode): self
+    {
+        $tbr = clone $this;
+        $tbr->mode = $mode;
+
+        return $tbr;
+    }
+
+    public function withVerifyPeer(bool $verify): self
+    {
+        $tbr = clone $this;
+        $tbr->verifyPeer = $verify;
+
+        return $tbr;
+    }
+}

--- a/src/Enum/SslMode.php
+++ b/src/Enum/SslMode.php
@@ -26,6 +26,7 @@ $oldReporting = error_reporting(error_reporting() & ~E_DEPRECATED);
  * @method static self ENABLE()
  * @method static self DISABLE()
  * @method static self FROM_URL()
+ * @method static self ENABLE_WITH_SELF_SIGNED()
  *
  * @extends TypedEnum<string>
  *
@@ -36,6 +37,7 @@ $oldReporting = error_reporting(error_reporting() & ~E_DEPRECATED);
 final class SslMode extends TypedEnum implements JsonSerializable
 {
     private const ENABLE = 'enable';
+    private const ENABLE_WITH_SELF_SIGNED = 'enable_with_self_signed';
     private const DISABLE = 'disable';
     private const FROM_URL = 'from_url';
 

--- a/src/Enum/SslMode.php
+++ b/src/Enum/SslMode.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Laudis Neo4j package.
+ *
+ * (c) Laudis technologies <http://laudis.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Enum;
+
+use const E_DEPRECATED;
+use function error_reporting;
+use JsonSerializable;
+use Laudis\TypedEnum\TypedEnum;
+
+/**
+ * Turn of error reporting for class definition. PHP Users of 8.1 receive a deprectation warning otherwise but
+ * it is not fixable from the minimum version 7.4 as it required the "mixed" keyword.
+ */
+$oldReporting = error_reporting(error_reporting() & ~E_DEPRECATED);
+
+/**
+ * @method static self ENABLE()
+ * @method static self DISABLE()
+ * @method static self FROM_URL()
+ *
+ * @extends TypedEnum<string>
+ *
+ * @psalm-immutable
+ *
+ * @psalm-suppress MutableDependency
+ */
+final class SslMode extends TypedEnum implements JsonSerializable
+{
+    private const ENABLE = 'enable';
+    private const DISABLE = 'disable';
+    private const FROM_URL = 'from_url';
+
+    public function __toString()
+    {
+        /** @noinspection MagicMethodsValidityInspection */
+        return $this->getValue();
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->getValue();
+    }
+}
+
+/**
+ * Turn back on old error reporting after class definition.
+ */
+error_reporting($oldReporting);

--- a/src/Neo4j/Neo4jDriver.php
+++ b/src/Neo4j/Neo4jDriver.php
@@ -19,6 +19,7 @@ use function is_string;
 use Laudis\Neo4j\Authentication\Authenticate;
 use Laudis\Neo4j\Bolt\BoltConnectionPool;
 use Laudis\Neo4j\Bolt\Session;
+use Laudis\Neo4j\Bolt\SslConfigurator;
 use Laudis\Neo4j\Common\Uri;
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
 use Laudis\Neo4j\Contracts\ConnectionPoolInterface;
@@ -98,7 +99,7 @@ final class Neo4jDriver implements DriverInterface
             return new self(
                 $uri,
                 $authenticate ?? Authenticate::fromUrl(),
-                new Neo4jConnectionPool(new BoltConnectionPool($configuration)),
+                new Neo4jConnectionPool(new BoltConnectionPool($configuration, new SslConfigurator())),
                 $configuration,
                 $formatter,
                 $socketTimeout
@@ -108,7 +109,7 @@ final class Neo4jDriver implements DriverInterface
         return new self(
             $uri,
             $authenticate ?? Authenticate::fromUrl(),
-            new Neo4jConnectionPool(new BoltConnectionPool($configuration)),
+            new Neo4jConnectionPool(new BoltConnectionPool($configuration, new SslConfigurator())),
             $configuration,
             OGMFormatter::create(),
             $socketTimeout

--- a/src/Neo4j/Neo4jDriver.php
+++ b/src/Neo4j/Neo4jDriver.php
@@ -92,13 +92,14 @@ final class Neo4jDriver implements DriverInterface
         }
 
         $socketTimeout ??= TransactionConfiguration::DEFAULT_TIMEOUT;
+        $configuration ??= DriverConfiguration::default();
 
         if ($formatter !== null) {
             return new self(
                 $uri,
                 $authenticate ?? Authenticate::fromUrl(),
-                new Neo4jConnectionPool(new BoltConnectionPool()),
-                $configuration ?? DriverConfiguration::default(),
+                new Neo4jConnectionPool(new BoltConnectionPool($configuration)),
+                $configuration,
                 $formatter,
                 $socketTimeout
             );
@@ -107,8 +108,8 @@ final class Neo4jDriver implements DriverInterface
         return new self(
             $uri,
             $authenticate ?? Authenticate::fromUrl(),
-            new Neo4jConnectionPool(new BoltConnectionPool()),
-            $configuration ?? DriverConfiguration::default(),
+            new Neo4jConnectionPool(new BoltConnectionPool($configuration)),
+            $configuration,
             OGMFormatter::create(),
             $socketTimeout
         );

--- a/tests/Integration/BasicDriverTest.php
+++ b/tests/Integration/BasicDriverTest.php
@@ -28,7 +28,7 @@ final class BasicDriverTest extends TestCase
         /** @var string|mixed $connections */
         $connections = $_ENV['NEO4J_CONNECTIONS'] ?? false;
         if (!is_string($connections)) {
-            Dotenv::createImmutable(__DIR__ . '/../../')->load();
+            Dotenv::createImmutable(__DIR__.'/../../')->load();
             /** @var string|mixed $connections */
             $connections = $_ENV['NEO4J_CONNECTIONS'] ?? false;
             if (!is_string($connections)) {

--- a/tests/Integration/BoltDriverIntegrationTest.php
+++ b/tests/Integration/BoltDriverIntegrationTest.php
@@ -36,7 +36,7 @@ final class BoltDriverIntegrationTest extends TestCase
         /** @var string|mixed $connections */
         $connections = $_ENV['NEO4J_CONNECTIONS'] ?? false;
         if (!is_string($connections)) {
-            Dotenv::createImmutable(__DIR__ . '/../../')->load();
+            Dotenv::createImmutable(__DIR__.'/../../')->load();
             /** @var string|mixed $connections */
             $connections = $_ENV['NEO4J_CONNECTIONS'] ?? false;
             if (!is_string($connections)) {

--- a/tests/Integration/ClientBuilderTest.php
+++ b/tests/Integration/ClientBuilderTest.php
@@ -26,7 +26,7 @@ final class ClientBuilderTest extends TestCase
         /** @var string|mixed $connections */
         $connections = $_ENV['NEO4J_CONNECTIONS'] ?? false;
         if (!is_string($connections)) {
-            Dotenv::createImmutable(__DIR__ . '/../../')->load();
+            Dotenv::createImmutable(__DIR__.'/../../')->load();
             /** @var string|mixed $connections */
             $connections = $_ENV['NEO4J_CONNECTIONS'] ?? false;
             if (!is_string($connections)) {
@@ -45,11 +45,12 @@ final class ClientBuilderTest extends TestCase
 
     public function testBoltSetupWithScheme(): void
     {
-        if ($this->getBoltUri() === null) {
+        $uri = $this->getBoltUri();
+        if ($uri === null) {
             self::markTestSkipped('No bolt uri provided');
         }
 
-        $client = ClientBuilder::create()->addBoltConnection('bolt', $this->getBoltUri())->build();
+        $client = ClientBuilder::create()->addBoltConnection('bolt', $uri)->build();
         $tsx = $client->beginTransaction();
         self::assertTrue(true);
         $tsx->rollback();
@@ -57,11 +58,12 @@ final class ClientBuilderTest extends TestCase
 
     public function testBoltSetupWithoutPort(): void
     {
-        if ($this->getBoltUri() === null) {
+        $uri = $this->getBoltUri();
+        if ($uri === null) {
             self::markTestSkipped('No bolt uri provided');
         }
 
-        $client = ClientBuilder::create()->addBoltConnection('bolt', $this->getBoltUri())->build();
+        $client = ClientBuilder::create()->addBoltConnection('bolt', $uri)->build();
         $tsx = $client->beginTransaction();
         self::assertTrue(true);
         $tsx->rollback();
@@ -69,11 +71,12 @@ final class ClientBuilderTest extends TestCase
 
     public function testBoltSetupWrongScheme(): void
     {
-        if ($this->getBoltUri() === null) {
+        $uri = $this->getBoltUri();
+        if ($uri === null) {
             self::markTestSkipped('No bolt uri provided');
         }
 
-        $client = ClientBuilder::create()->addBoltConnection('bolt', $this->getBoltUri())->build();
+        $client = ClientBuilder::create()->addBoltConnection('bolt', $uri)->build();
         $tsx = $client->beginTransaction();
         self::assertTrue(true);
         $tsx->rollback();

--- a/tests/Integration/EnvironmentAwareIntegrationTest.php
+++ b/tests/Integration/EnvironmentAwareIntegrationTest.php
@@ -88,7 +88,7 @@ abstract class EnvironmentAwareIntegrationTest extends TestCase
     {
         $connections = $_ENV['NEO4J_CONNECTIONS'] ?? false;
         if (!is_string($connections)) {
-            Dotenv::createImmutable(__DIR__ . '/../../')->load();
+            Dotenv::createImmutable(__DIR__.'/../../')->load();
             /** @var string|mixed $connections */
             $connections = $_ENV['NEO4J_CONNECTIONS'] ?? false;
             if (!is_string($connections)) {

--- a/tests/Unit/BoltCypherFormatterTest.php
+++ b/tests/Unit/BoltCypherFormatterTest.php
@@ -20,6 +20,7 @@ use Bolt\structures\Path;
 use Bolt\structures\UnboundRelationship;
 use Laudis\Neo4j\Common\BoltConnection;
 use Laudis\Neo4j\Databags\DatabaseInfo;
+use Laudis\Neo4j\Databags\DriverConfiguration;
 use Laudis\Neo4j\Enum\AccessMode;
 use Laudis\Neo4j\Enum\ConnectionProtocol;
 use Laudis\Neo4j\Formatter\BasicFormatter;
@@ -95,6 +96,7 @@ final class BoltCypherFormatterTest extends TestCase
             ConnectionProtocol::BOLT_V43(),
             AccessMode::READ(),
             new DatabaseInfo(''),
+            DriverConfiguration::default(),
             static fn () => new Bolt($connection),
         );
     }

--- a/tests/Unit/SslConfiguratorTest.php
+++ b/tests/Unit/SslConfiguratorTest.php
@@ -1,8 +1,117 @@
 <?php
 
+/*
+ * This file is part of the Laudis Neo4j package.
+ *
+ * (c) Laudis technologies <http://laudis.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Laudis\Neo4j\Tests\Unit;
 
-class SslConfiguratorTest
-{
+use Laudis\Neo4j\Bolt\SslConfigurator;
+use Laudis\Neo4j\Common\Uri;
+use Laudis\Neo4j\Databags\DriverConfiguration;
+use Laudis\Neo4j\Databags\SslConfiguration;
+use Laudis\Neo4j\Enum\SslMode;
+use PHPUnit\Framework\TestCase;
 
+/**
+ * @psalm-suppress PossiblyUndefinedStringArrayOffset
+ */
+final class SslConfiguratorTest extends TestCase
+{
+    private SslConfigurator $configurator;
+
+    public function setUp(): void
+    {
+        $this->configurator = new SslConfigurator();
+    }
+
+    public function testDisablePeerVerification(): void
+    {
+        $config = DriverConfiguration::default()
+            ->withSslConfiguration(
+                SslConfiguration::default()
+                    ->withVerifyPeer(false)
+                    ->withMode(SslMode::ENABLE())
+            );
+
+        $uri = Uri::create('');
+        $array = $this->configurator->configure($uri, $uri, null, $config);
+
+        self::assertNotNull($array);
+        self::assertArrayHasKey('verify_peer', $array);
+        self::assertArrayNotHasKey('allow_self_signed', $array);
+        self::assertFalse($array['verify_peer']);
+    }
+
+    public function testEnablePeerVerification(): void
+    {
+        $config = DriverConfiguration::default()
+            ->withSslConfiguration(
+                SslConfiguration::default()
+                    ->withVerifyPeer(true)
+                    ->withMode(SslMode::ENABLE())
+            );
+
+        $uri = Uri::create('');
+        $array = $this->configurator->configure($uri, $uri, null, $config);
+
+        self::assertNotNull($array);
+        self::assertArrayHasKey('verify_peer', $array);
+        self::assertArrayNotHasKey('allow_self_signed', $array);
+        self::assertTrue($array['verify_peer']);
+    }
+
+    public function testSelfSigned(): void
+    {
+        $config = DriverConfiguration::default()
+            ->withSslConfiguration(
+                SslConfiguration::default()
+                    ->withVerifyPeer(true)
+                    ->withMode(SslMode::ENABLE_WITH_SELF_SIGNED())
+            );
+
+        $uri = Uri::create('');
+        $array = $this->configurator->configure($uri, $uri, null, $config);
+
+        self::assertNotNull($array);
+        self::assertArrayHasKey('allow_self_signed', $array);
+        self::assertTrue($array['allow_self_signed']);
+    }
+
+    public function testFromUriNull(): void
+    {
+        $config = DriverConfiguration::default()
+            ->withSslConfiguration(
+                SslConfiguration::default()
+                    ->withVerifyPeer(true)
+                    ->withMode(SslMode::FROM_URL())
+            );
+
+        $uri = Uri::create('neo4j://localhost');
+        $array = $this->configurator->configure($uri, $uri, null, $config);
+
+        self::assertNull($array);
+    }
+
+    public function testFromUri(): void
+    {
+        $config = DriverConfiguration::default()
+            ->withSslConfiguration(
+                SslConfiguration::default()
+                    ->withMode(SslMode::FROM_URL())
+            );
+
+        $uri = Uri::create('neo4j+s://localhost');
+        $array = $this->configurator->configure($uri, $uri, null, $config);
+
+        self::assertNotNull($array);
+        self::assertArrayHasKey('verify_peer', $array);
+        self::assertArrayNotHasKey('allow_self_signed', $array);
+        self::assertTrue($array['verify_peer']);
+    }
 }

--- a/tests/Unit/SslConfiguratorTest.php
+++ b/tests/Unit/SslConfiguratorTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laudis\Neo4j\Tests\Unit;
+
+class SslConfiguratorTest
+{
+
+}


### PR DESCRIPTION
It is now possible to configure SSL behaviour at the driver level.

This PR is in reaction to Issue #95 

Possible examples are:

```php
$config = DriverConfiguration::default()
            ->withSslConfiguration(
                SslConfiguration::default()
                    ->withVerifyPeer(false) //disables peer verification
                    ->withMode(SslMode::FROM_URL()) // looks at the URL to determine the enabling of ssl
            );
            
$driver = \Laudis\Neo4j\Basic\Driver::create('neo4j+s://localhost', $config);

$client = \Laudis\Neo4j\ClientBuilder::create()
            ->withDefaultDriverConfiguration($config)
            ->withDriver('default', 'neo4j+s://localhost')
            ->build();
```