### PR TITLE
change Node $id type to mixed instead of int (minor)

### DIFF
--- a/src/Types/Node.php
+++ b/src/Types/Node.php
@@ -25,12 +25,12 @@ use function sprintf;
  *
  * @psalm-immutable
  *
- * @extends AbstractPropertyObject<OGMTypes, int|string|CypherMap<OGMTypes>>
- * @extends AbstractPropertyObject<OGMTypes, int|CypherList<string>|CypherMap<OGMTypes>>
+ * @extends AbstractPropertyObject<OGMTypes, mixed|string|CypherMap<OGMTypes>>
+ * @extends AbstractPropertyObject<OGMTypes, mixed|CypherList<string>|CypherMap<OGMTypes>>
  */
 final class Node extends AbstractPropertyObject
 {
-    private int $id;
+    private mixed $id;
     /** @var CypherList<string> */
     private CypherList $labels;
     /** @var CypherMap<OGMTypes> */
@@ -40,7 +40,7 @@ final class Node extends AbstractPropertyObject
      * @param CypherList<string>  $labels
      * @param CypherMap<OGMTypes> $properties
      */
-    public function __construct(int $id, CypherList $labels, CypherMap $properties)
+    public function __construct(mixed $id, CypherList $labels, CypherMap $properties)
     {
         $this->id = $id;
         $this->labels = $labels;
@@ -83,7 +83,7 @@ final class Node extends AbstractPropertyObject
      * @deprecated
      * @see self::getId
      */
-    public function id(): int
+    public function id(): mixed
     {
         return $this->id;
     }
@@ -91,7 +91,7 @@ final class Node extends AbstractPropertyObject
     /**
      * The id of the node.
      */
-    public function getId(): int
+    public function getId(): mixed
     {
         return $this->id;
     }
@@ -115,7 +115,7 @@ final class Node extends AbstractPropertyObject
     /**
      * @psalm-suppress ImplementedReturnTypeMismatch False positive.
      *
-     * @return array{id: int, labels: CypherList<string>, properties: CypherMap<OGMTypes>}
+     * @return array{id: mixed, labels: CypherList<string>, properties: CypherMap<OGMTypes>}
      */
     public function toArray(): array
     {


### PR DESCRIPTION
Encountered this issue when using a string primary key (UUID):

```
exception: "TypeError"
file: "/var/www/html/vendor/laudis/neo4j-php-client/src/Types/Node.php"
line: 43
message: "Laudis\\Neo4j\\Types\\Node::__construct(): Argument #1 ($id) must be of type int, string given
```