### PR TITLE
Pass down session configuration in basic Driver

### DIFF
--- a/src/Basic/Driver.php
+++ b/src/Basic/Driver.php
@@ -46,7 +46,7 @@ final class Driver implements DriverInterface
      */
     public function createSession(?SessionConfiguration $config = null): Session
     {
-        return new Session($this->driver->createSession());
+        return new Session($this->driver->createSession($config));
     }
 
     public function verifyConnectivity(): bool


### PR DESCRIPTION
The session configuration passed into `createSession` on the basic Driver wrapper is not being passed down to the contained driver's method.