### PR TITLE
Graceful driver fallback

### DIFF
--- a/src/Basic/Client.php
+++ b/src/Basic/Client.php
@@ -57,9 +57,6 @@ final class Client implements ClientInterface
         return new UnmanagedTransaction($this->client->beginTransaction($statements, $alias, $config));
     }
 
-    /**
-     * @psalm-mutation-free
-     */
     public function getDriver(?string $alias): DriverInterface
     {
         return $this->client->getDriver($alias);

--- a/src/Client.php
+++ b/src/Client.php
@@ -13,15 +13,11 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j;
 
-use function array_key_exists;
-use InvalidArgumentException;
+use Laudis\Neo4j\Common\DriverSetupManager;
 use Laudis\Neo4j\Contracts\ClientInterface;
 use Laudis\Neo4j\Contracts\DriverInterface;
-use Laudis\Neo4j\Contracts\FormatterInterface;
 use Laudis\Neo4j\Contracts\SessionInterface;
 use Laudis\Neo4j\Contracts\UnmanagedTransactionInterface;
-use Laudis\Neo4j\Databags\DriverConfiguration;
-use Laudis\Neo4j\Databags\DriverSetup;
 use Laudis\Neo4j\Databags\SessionConfiguration;
 use Laudis\Neo4j\Databags\Statement;
 use Laudis\Neo4j\Databags\TransactionConfiguration;
@@ -37,26 +33,24 @@ use Laudis\Neo4j\Types\CypherList;
  */
 final class Client implements ClientInterface
 {
-    private const DEFAULT_DRIVER_CONFIG = 'bolt://localhost:7687';
-    /** @var non-empty-array<string, DriverInterface<ResultFormat>> */
-    private array $drivers;
-    /** @psalm-readonly */
-    private ?string $default;
     private SessionConfiguration $defaultSessionConfiguration;
     private TransactionConfiguration $defaultTransactionConfiguration;
+    /** @var DriverSetupManager<ResultFormat> */
+    private DriverSetupManager $driverSetups;
 
     /**
      * @psalm-mutation-free
      *
-     * @param array<string, DriverSetup>       $driverSetups
-     * @param FormatterInterface<ResultFormat> $formatter
+     * @param DriverSetupManager<ResultFormat> $driverSetups
      */
-    public function __construct(array $driverSetups, DriverConfiguration $defaultDriverConfiguration, SessionConfiguration $defaultSessionConfiguration, TransactionConfiguration $defaultTransactionConfiguration, FormatterInterface $formatter, ?string $default)
-    {
-        $this->default = $default;
-        $this->drivers = $this->createDrivers($driverSetups, $formatter, $defaultDriverConfiguration);
+    public function __construct(
+        DriverSetupManager $driverSetups,
+        SessionConfiguration $defaultSessionConfiguration,
+        TransactionConfiguration $defaultTransactionConfiguration
+    ) {
         $this->defaultSessionConfiguration = $defaultSessionConfiguration;
         $this->defaultTransactionConfiguration = $defaultTransactionConfiguration;
+        $this->driverSetups = $driverSetups;
     }
 
     public function run(string $statement, iterable $parameters = [], ?string $alias = null)
@@ -84,23 +78,12 @@ final class Client implements ClientInterface
         return $session->beginTransaction($statements, $config);
     }
 
-    /**
-     * @psalm-mutation-free
-     */
     public function getDriver(?string $alias): DriverInterface
     {
-        $alias = $this->decideAlias($alias);
-
-        if (!array_key_exists($alias, $this->drivers)) {
-            throw new InvalidArgumentException(sprintf('The provided alias: "%s" was not found in the client', $alias));
-        }
-
-        return $this->drivers[$alias];
+        return $this->driverSetups->getDriver($alias);
     }
 
     /**
-     * @psalm-mutation-free
-     *
      * @return SessionInterface<ResultFormat>
      */
     private function startSession(?string $alias, SessionConfiguration $configuration): SessionInterface
@@ -131,41 +114,7 @@ final class Client implements ClientInterface
 
     public function verifyConnectivity(?string $driver = null): bool
     {
-        return $this->getDriver($driver)->verifyConnectivity();
-    }
-
-    /**
-     * @psalm-mutation-free
-     */
-    private function decideAlias(?string $alias): string
-    {
-        return $alias ?? $this->default ?? array_key_first($this->drivers);
-    }
-
-    /**
-     * @psalm-mutation-free
-     *
-     * @param array<string, DriverSetup>       $driverSetups
-     * @param FormatterInterface<ResultFormat> $formatter
-     *
-     * @return non-empty-array<string, DriverInterface<ResultFormat>>
-     */
-    private function createDrivers(array $driverSetups, FormatterInterface $formatter, DriverConfiguration $configuration): array
-    {
-        if (count($driverSetups) === 0) {
-            $drivers = ['default' => DriverFactory::create(self::DEFAULT_DRIVER_CONFIG, null, null, $formatter)];
-        } else {
-            $drivers = [];
-            foreach ($driverSetups as $alias => $setup) {
-                $uri = $setup->getUri();
-                $auth = $setup->getAuth();
-
-                $drivers[$alias] = DriverFactory::create($uri, $configuration, $auth, $formatter);
-            }
-        }
-
-        /** @var non-empty-array<string, DriverInterface<ResultFormat>> */
-        return $drivers;
+        return $this->driverSetups->verifyConnectivity($driver);
     }
 
     private function getTsxConfig(?TransactionConfiguration $config): TransactionConfiguration

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -28,7 +28,6 @@ use Laudis\Neo4j\Databags\SessionConfiguration;
 use Laudis\Neo4j\Databags\SummarizedResult;
 use Laudis\Neo4j\Databags\TransactionConfiguration;
 use Laudis\Neo4j\Exception\UnsupportedScheme;
-use Laudis\Neo4j\Formatter\OGMFormatter;
 use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
 use Laudis\Neo4j\Http\HttpConfig;
 use Laudis\Neo4j\Types\CypherMap;

--- a/src/Common/DriverSetupManager.php
+++ b/src/Common/DriverSetupManager.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Common;
+
+use function array_key_exists;
+use function array_key_first;
+use function array_reduce;
+use Countable;
+use InvalidArgumentException;
+use Laudis\Neo4j\Authentication\Authenticate;
+use Laudis\Neo4j\Contracts\DriverInterface;
+use Laudis\Neo4j\Contracts\FormatterInterface;
+use Laudis\Neo4j\Databags\DriverConfiguration;
+use Laudis\Neo4j\Databags\DriverSetup;
+use Laudis\Neo4j\DriverFactory;
+use const PHP_INT_MIN;
+use RuntimeException;
+use SplPriorityQueue;
+use function sprintf;
+
+/**
+ * @template ResultFormat
+ */
+class DriverSetupManager implements Countable
+{
+    private const DEFAULT_DRIVER_CONFIG = 'bolt://localhost:7687';
+
+    /** @var array<string, SplPriorityQueue<int, DriverSetup>> */
+    private array $driverSetups = [];
+    private array $drivers = [];
+    private ?string $default = null;
+    private FormatterInterface $formatter;
+    private DriverConfiguration $configuration;
+
+    /**
+     * @param FormatterInterface<ResultFormat> $formatter
+     * @param DriverConfiguration $configuration
+     */
+    public function __construct(FormatterInterface $formatter, DriverConfiguration $configuration)
+    {
+        $this->formatter = $formatter;
+        $this->configuration = $configuration;
+    }
+
+    public function addSetup(DriverSetup $setup, ?string $alias = null, ?int $priority = 0): void
+    {
+        $alias ??= $this->decideAlias($alias);
+
+        $this->driverSetups[$alias] ??= new SplPriorityQueue();
+        $this->driverSetups[$alias]->insert($setup, $priority ?? 0);
+    }
+
+    /**
+     * @return DriverInterface<ResultFormat>
+     */
+    public function getDriver(?string $alias = null): DriverInterface
+    {
+        $alias ??= $this->decideAlias($alias);
+
+        if (!array_key_exists($alias, $this->driverSetups)) {
+            if ($alias !== 'default') {
+                throw new InvalidArgumentException(sprintf('Cannot find a driver setup with alias: "%s"', $alias));
+            }
+
+            $this->driverSetups['default'] = new SplPriorityQueue();
+            $setup = new DriverSetup(Uri::create(self::DEFAULT_DRIVER_CONFIG), Authenticate::disabled());
+            $this->driverSetups['default']->insert($setup, PHP_INT_MIN);
+
+            return $this->getDriver();
+        }
+
+        if (array_key_exists($alias, $this->drivers)) {
+            return $this->drivers[$alias];
+        }
+
+        $urisTried = [];
+        foreach ($this->driverSetups[$alias] as $setup) {
+            $uri = $setup->getUri();
+            $auth = $setup->getAuth();
+
+            $driver = DriverFactory::create($uri, $this->configuration, $auth, $this->formatter);
+            $urisTried[] = $uri->__toString();
+            if ($driver->verifyConnectivity()) {
+                $this->drivers[$alias] = $driver;
+
+                return $driver;
+            }
+        }
+
+        throw new RuntimeException(sprintf('Cannot connect to any server on alias: %s with Uris: (\'%s\')', $alias, implode('\', ', array_unique($urisTried))));
+    }
+
+    public function verifyConnectivity(?string $alias = null): bool
+    {
+        try {
+            $this->getDriver($alias);
+        } catch (RuntimeException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    private function decideAlias(?string $alias): string
+    {
+        return $alias ?? $this->default ?? array_key_first($this->driverSetups) ?? 'default';
+    }
+
+    public function setDefault(string $default): void
+    {
+        $this->default = $default;
+    }
+
+    public function count(): int
+    {
+        return array_reduce($this->driverSetups, static fn (int $acc, SplPriorityQueue $x) => $acc + $x->count(), 0);
+    }
+}

--- a/src/Common/DriverSetupManager.php
+++ b/src/Common/DriverSetupManager.php
@@ -36,6 +36,7 @@ class DriverSetupManager implements Countable
 
     /** @var array<string, SplPriorityQueue<int, DriverSetup>> */
     private array $driverSetups = [];
+    /** @var array<string, DriverInterface<ResultFormat>> */
     private array $drivers = [];
     private ?string $default = null;
     private FormatterInterface $formatter;
@@ -61,6 +62,7 @@ class DriverSetupManager implements Countable
 
         $setups = $this->driverSetups;
 
+        /** @var SplPriorityQueue<int, DriverSetup> */
         $setups[$alias] ??= new SplPriorityQueue();
         /** @psalm-suppress ImpureMethodCall */
         $setups[$alias]->insert($setup, $priority ?? 0);
@@ -83,6 +85,7 @@ class DriverSetupManager implements Countable
                 throw new InvalidArgumentException(sprintf('Cannot find a driver setup with alias: "%s"', $alias));
             }
 
+            /** @var SplPriorityQueue<int, DriverSetup> */
             $this->driverSetups['default'] = new SplPriorityQueue();
             $setup = new DriverSetup(Uri::create(self::DEFAULT_DRIVER_CONFIG), Authenticate::disabled());
             $this->driverSetups['default']->insert($setup, PHP_INT_MIN);

--- a/src/Contracts/ClientInterface.php
+++ b/src/Contracts/ClientInterface.php
@@ -70,9 +70,9 @@ interface ClientInterface extends TransactionInterface
     /**
      * Gets the driver with the provided alias. Gets the default driver if no alias is provided.
      *
-     * @return DriverInterface<ResultFormat>
+     * The driver is guaranteed to have its connectivity verified at least once during its lifetime.
      *
-     * @psalm-mutation-free
+     * @return DriverInterface<ResultFormat>
      */
     public function getDriver(?string $alias): DriverInterface;
 

--- a/src/Databags/DriverSetup.php
+++ b/src/Databags/DriverSetup.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Laudis\Neo4j\Databags;
 
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
-use Laudis\Neo4j\Contracts\FormatterInterface;
 use Psr\Http\Message\UriInterface;
 
 /**

--- a/src/Databags/DriverSetup.php
+++ b/src/Databags/DriverSetup.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Laudis\Neo4j\Databags;
 
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
+use Laudis\Neo4j\Contracts\FormatterInterface;
 use Psr\Http\Message\UriInterface;
 
 /**

--- a/tests/Integration/ClientIntegrationTest.php
+++ b/tests/Integration/ClientIntegrationTest.php
@@ -284,7 +284,7 @@ CYPHER, ['test' => 'a', 'otherTest' => 'b']));
     public function testInvalidConnection(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided alias: "gh" was not found in the client');
+        $this->expectExceptionMessage('Cannot find a driver setup with alias: "gh"');
 
         $this->getClient()->transaction(static fn (TransactionInterface $tsx) => $tsx->run('RETURN 1 AS x'), 'gh');
     }


### PR DESCRIPTION
Implemented a graceful driver fallback in the client as discussed in #136 

When building the client you can now add multiple configurations at once as the method signature now looks like this:
`withDriver(string $alias, string $url, ?AuthenticateInterface $authentication = null, ?int $priority = 0)`

Under the hood, it will add a preconfigured alias with the provided URL in a priority queue. The priority can be configured through the priority number. If you don't provide a number, they will be added in order.

> Note: It is really important to realise the priority queue is per preconfigured alias. The reasoning being that other alias can point to entirely different systems which can easily lead to undefined behaviour.

The very first time the client uses the driver with the alias, it will verify the connection of the first driver before it actually uses them. It will move on to the next one if the other one doesn't work. If no drivers' connection can be verified, an error will be thrown.
