### PR TITLE
Preparation for migration to bolt V5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "psr/http-client": "^1.0",
         "php-http/message": "^1.0",
         "php-http/message-factory": "^1.0",
-        "stefanak-michal/bolt": "^4.1",
+        "stefanak-michal/bolt": "dev-protocol_messages_as_traits",
         "symfony/polyfill-php80": "^1.2",
         "ext-json": "*"
     },

--- a/src/Authentication/BasicAuth.php
+++ b/src/Authentication/BasicAuth.php
@@ -15,7 +15,7 @@ namespace Laudis\Neo4j\Authentication;
 
 use function base64_encode;
 use Bolt\helpers\Auth;
-use Bolt\protocol\V3;
+use Bolt\protocol\AProtocol;
 use Exception;
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
 use Psr\Http\Message\RequestInterface;
@@ -57,7 +57,7 @@ final class BasicAuth implements AuthenticateInterface
     /**
      * @throws Exception
      */
-    public function authenticateBolt(V3 $bolt, string $userAgent): array
+    public function authenticateBolt(AProtocol $bolt, string $userAgent): array
     {
         /** @var array{server: string, connection_id: string, hints: list} */
         return $bolt->hello(Auth::basic($this->username, $this->password, $userAgent));

--- a/src/Authentication/BasicAuth.php
+++ b/src/Authentication/BasicAuth.php
@@ -57,9 +57,9 @@ final class BasicAuth implements AuthenticateInterface
     /**
      * @throws Exception
      */
-    public function authenticateBolt(AProtocol $bolt, string $userAgent): array
+    public function authenticateBolt(AProtocol $protocol, string $userAgent): array
     {
         /** @var array{server: string, connection_id: string, hints: list} */
-        return $bolt->hello(Auth::basic($this->username, $this->password, $userAgent));
+        return $protocol->hello(Auth::basic($this->username, $this->password, $userAgent));
     }
 }

--- a/src/Authentication/KerberosAuth.php
+++ b/src/Authentication/KerberosAuth.php
@@ -48,9 +48,9 @@ final class KerberosAuth implements AuthenticateInterface
             ->withHeader('User-Agent', $userAgent);
     }
 
-    public function authenticateBolt(AProtocol $bolt, string $userAgent): array
+    public function authenticateBolt(AProtocol $protocol, string $userAgent): array
     {
         /** @var array{server: string, connection_id: string, hints: list} */
-        return $bolt->hello(Auth::bearer($this->token, $userAgent));
+        return $protocol->hello(Auth::bearer($this->token, $userAgent));
     }
 }

--- a/src/Authentication/KerberosAuth.php
+++ b/src/Authentication/KerberosAuth.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Laudis\Neo4j\Authentication;
 
 use Bolt\helpers\Auth;
-use Bolt\protocol\V3;
+use Bolt\protocol\AProtocol;
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
@@ -48,7 +48,7 @@ final class KerberosAuth implements AuthenticateInterface
             ->withHeader('User-Agent', $userAgent);
     }
 
-    public function authenticateBolt(V3 $bolt, string $userAgent): array
+    public function authenticateBolt(AProtocol $bolt, string $userAgent): array
     {
         /** @var array{server: string, connection_id: string, hints: list} */
         return $bolt->hello(Auth::bearer($this->token, $userAgent));

--- a/src/Authentication/NoAuth.php
+++ b/src/Authentication/NoAuth.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Laudis\Neo4j\Authentication;
 
 use Bolt\helpers\Auth;
-use Bolt\protocol\V3;
+use Bolt\protocol\AProtocol;
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
@@ -37,7 +37,7 @@ final class NoAuth implements AuthenticateInterface
         return $request->withHeader('User-Agent', $userAgent);
     }
 
-    public function authenticateBolt(V3 $bolt, string $userAgent): array
+    public function authenticateBolt(AProtocol $bolt, string $userAgent): array
     {
         /** @var array{server: string, connection_id: string, hints: list} */
         return $bolt->hello(Auth::none($userAgent));

--- a/src/Authentication/NoAuth.php
+++ b/src/Authentication/NoAuth.php
@@ -37,9 +37,9 @@ final class NoAuth implements AuthenticateInterface
         return $request->withHeader('User-Agent', $userAgent);
     }
 
-    public function authenticateBolt(AProtocol $bolt, string $userAgent): array
+    public function authenticateBolt(AProtocol $protocol, string $userAgent): array
     {
         /** @var array{server: string, connection_id: string, hints: list} */
-        return $bolt->hello(Auth::none($userAgent));
+        return $protocol->hello(Auth::none($userAgent));
     }
 }

--- a/src/Authentication/OpenIDConnectAuth.php
+++ b/src/Authentication/OpenIDConnectAuth.php
@@ -43,9 +43,9 @@ final class OpenIDConnectAuth implements AuthenticateInterface
             ->withHeader('User-Agent', $userAgent);
     }
 
-    public function authenticateBolt(AProtocol $bolt, string $userAgent): array
+    public function authenticateBolt(AProtocol $protocol, string $userAgent): array
     {
         /** @var array{server: string, connection_id: string, hints: list} */
-        return $bolt->hello(Auth::bearer($this->token));
+        return $protocol->hello(Auth::bearer($this->token));
     }
 }

--- a/src/Authentication/OpenIDConnectAuth.php
+++ b/src/Authentication/OpenIDConnectAuth.php
@@ -12,7 +12,7 @@
 namespace Laudis\Neo4j\Authentication;
 
 use Bolt\helpers\Auth;
-use Bolt\protocol\V3;
+use Bolt\protocol\AProtocol;
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
@@ -43,7 +43,7 @@ final class OpenIDConnectAuth implements AuthenticateInterface
             ->withHeader('User-Agent', $userAgent);
     }
 
-    public function authenticateBolt(V3 $bolt, string $userAgent): array
+    public function authenticateBolt(AProtocol $bolt, string $userAgent): array
     {
         /** @var array{server: string, connection_id: string, hints: list} */
         return $bolt->hello(Auth::bearer($this->token));

--- a/src/Bolt/BoltConnection.php
+++ b/src/Bolt/BoltConnection.php
@@ -254,13 +254,13 @@ final class BoltConnection implements ConnectionInterface
     public function discard(?int $qid): void
     {
         try {
-            $extra = $this->buildResultExtra(null, $qid);
             $bolt = $this->protocol();
 
             if ($bolt instanceof V4 || $bolt instanceof V4_1 || $bolt instanceof V4_2 || $bolt instanceof V4_3 || $bolt instanceof V4_4) {
+                $extra = $this->buildResultExtra(null, $qid);
                 $result = $bolt->discard($extra);
             } else {
-                $result = $bolt->discardAll($extra);
+                $result = $bolt->discardAll();
             }
 
             $this->interpretResult($result);
@@ -369,14 +369,13 @@ final class BoltConnection implements ConnectionInterface
      */
     public function pull(?int $qid, ?int $fetchSize): array
     {
-        $extra = $this->buildResultExtra($fetchSize, $qid);
-
         $bolt = $this->protocol();
         try {
             if ($bolt instanceof V3) {
                 /** @var non-empty-list<list> */
-                $tbr = $bolt->pullAll($extra);
+                $tbr = $bolt->pullAll();
             } else {
+                $extra = $this->buildResultExtra($fetchSize, $qid);
                 /** @var non-empty-list<list> */
                 $tbr = $bolt->pull($extra);
             }

--- a/src/Bolt/BoltConnectionPool.php
+++ b/src/Bolt/BoltConnectionPool.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Bolt;
 
-use Bolt\protocol\V3;
+use Bolt\protocol\AProtocol;
 use Exception;
 use function explode;
 use Laudis\Neo4j\BoltFactory;
@@ -31,7 +31,7 @@ use Throwable;
 /**
  * Manages singular Bolt connections.
  *
- * @implements ConnectionPoolInterface<V3>
+ * @implements ConnectionPoolInterface<AProtocol>
  */
 final class BoltConnectionPool implements ConnectionPoolInterface
 {

--- a/src/Bolt/BoltConnectionPool.php
+++ b/src/Bolt/BoltConnectionPool.php
@@ -13,7 +13,12 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Bolt;
 
-use Bolt\protocol\AProtocol;
+use Bolt\protocol\V3;
+use Bolt\protocol\V4;
+use Bolt\protocol\V4_1;
+use Bolt\protocol\V4_2;
+use Bolt\protocol\V4_3;
+use Bolt\protocol\V4_4;
 use Exception;
 use function explode;
 use Laudis\Neo4j\BoltFactory;
@@ -31,7 +36,7 @@ use Throwable;
 /**
  * Manages singular Bolt connections.
  *
- * @implements ConnectionPoolInterface<AProtocol>
+ * @implements ConnectionPoolInterface<V3|V4|V4_1|V4_2|V4_3|V4_4>
  */
 final class BoltConnectionPool implements ConnectionPoolInterface
 {

--- a/src/BoltFactory.php
+++ b/src/BoltFactory.php
@@ -19,7 +19,6 @@ use Bolt\connection\Socket;
 use Bolt\connection\StreamSocket;
 use Bolt\error\ConnectException;
 use Bolt\error\MessageException;
-use Bolt\protocol\V3;
 use Exception;
 use function extension_loaded;
 use Laudis\Neo4j\Bolt\SslConfigurator;
@@ -58,7 +57,7 @@ final class BoltFactory
     /**
      * @throws Exception
      *
-     * @return array{0: V3, 1: array{server: string, connection_id: string, hints: list}}
+     * @return array{0: AProtocol, 1: array{server: string, connection_id: string, hints: list}}
      */
     public function build(): array
     {
@@ -71,7 +70,7 @@ final class BoltFactory
                 $build = $this->bolt->build();
             }
 
-            if (!$build instanceof V3) {
+            if (version_compare($build->getVersion(), '3', '<')) {
                 throw new RuntimeException('Client only supports bolt version 3 and up.');
             }
 

--- a/src/BoltFactory.php
+++ b/src/BoltFactory.php
@@ -82,7 +82,6 @@ final class BoltFactory
                 throw new RuntimeException('Client only supports bolt version 3 and up.');
             }
 
-            /** @var V3|V4|V4_1|V4_2|V4_3|V4_4 $build */
             $response = $this->auth->authenticateBolt($build, $this->userAgent);
         } catch (MessageException $e) {
             throw Neo4jException::fromMessageException($e);

--- a/src/Contracts/AuthenticateInterface.php
+++ b/src/Contracts/AuthenticateInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Contracts;
 
-use Bolt\protocol\V3;
+use Bolt\protocol\AProtocol;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -31,5 +31,5 @@ interface AuthenticateInterface
      *
      * @return array{server: string, connection_id: string, hints: list}
      */
-    public function authenticateBolt(V3 $bolt, string $userAgent): array;
+    public function authenticateBolt(AProtocol $bolt, string $userAgent): array;
 }

--- a/src/Contracts/AuthenticateInterface.php
+++ b/src/Contracts/AuthenticateInterface.php
@@ -14,6 +14,12 @@ declare(strict_types=1);
 namespace Laudis\Neo4j\Contracts;
 
 use Bolt\protocol\AProtocol;
+use Bolt\protocol\V3;
+use Bolt\protocol\V4;
+use Bolt\protocol\V4_1;
+use Bolt\protocol\V4_2;
+use Bolt\protocol\V4_3;
+use Bolt\protocol\V4_4;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -29,7 +35,9 @@ interface AuthenticateInterface
     /**
      * Authenticates a Bolt connection with the provided configuration Uri and userAgent.
      *
+     * @param V3|V4|V4_1|V4_2|V4_3|V4_4 $protocol
+     *
      * @return array{server: string, connection_id: string, hints: list}
      */
-    public function authenticateBolt(AProtocol $bolt, string $userAgent): array;
+    public function authenticateBolt(AProtocol $protocol, string $userAgent): array;
 }

--- a/src/Enum/ConnectionProtocol.php
+++ b/src/Enum/ConnectionProtocol.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Enum;
 
-use Bolt\protocol\V3;
+use Bolt\protocol\AProtocol;
 use const E_DEPRECATED;
 use function error_reporting;
 use JsonSerializable;
@@ -57,7 +57,7 @@ final class ConnectionProtocol extends TypedEnum implements JsonSerializable
      *
      * @psalm-suppress ImpureMethodCall
      */
-    public static function determineBoltVersion(V3 $bolt): self
+    public static function determineBoltVersion(AProtocol $bolt): self
     {
         $version = self::resolve($bolt->getVersion());
 

--- a/src/Neo4j/Neo4jConnectionPool.php
+++ b/src/Neo4j/Neo4jConnectionPool.php
@@ -18,6 +18,8 @@ use function array_unique;
 use Bolt\protocol\AProtocol;
 use Bolt\protocol\V3;
 use Bolt\protocol\V4;
+use Bolt\protocol\V4_1;
+use Bolt\protocol\V4_2;
 use Bolt\protocol\V4_3;
 use Bolt\protocol\V4_4;
 use function count;
@@ -109,7 +111,7 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
     }
 
     /**
-     * @param ConnectionInterface<AProtocol> $connection
+     * @param ConnectionInterface<V3|V4|V4_1|V4_2|V4_3|V4_4> $connection
      *
      * @throws Exception
      */
@@ -125,7 +127,7 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
             return $this->useRouteMessage($bolt, $config);
         }
 
-        if ($bolt instanceof V4) {
+        if ($bolt instanceof V4 || $bolt instanceof V4_1 || $bolt instanceof V4_2) {
             return $this->useRoutingTable($bolt);
         }
 
@@ -153,9 +155,11 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
     }
 
     /**
+     * @param V4|V4_1|V4_2 $bolt
+     *
      * @throws Exception
      */
-    private function useRoutingTable(V4 $bolt): RoutingTable
+    private function useRoutingTable(AProtocol $bolt): RoutingTable
     {
         $bolt->run('CALL dbms.routing.getRoutingTable({context: []})');
         /** @var array{0: array{0: int, 1: list<array{addresses: list<string>, role:string}>}} */

--- a/src/Neo4j/Neo4jConnectionPool.php
+++ b/src/Neo4j/Neo4jConnectionPool.php
@@ -15,6 +15,7 @@ namespace Laudis\Neo4j\Neo4j;
 
 use function array_slice;
 use function array_unique;
+use Bolt\protocol\AProtocol;
 use Bolt\protocol\V3;
 use Bolt\protocol\V4;
 use Bolt\protocol\V4_3;
@@ -40,7 +41,7 @@ use function time;
  *
  * @psalm-import-type BasicDriver from \Laudis\Neo4j\Contracts\DriverInterface
  *
- * @implements ConnectionPoolInterface<V3>
+ * @implements ConnectionPoolInterface<AProtocol>
  */
 final class Neo4jConnectionPool implements ConnectionPoolInterface
 {
@@ -108,7 +109,7 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
     }
 
     /**
-     * @param ConnectionInterface<V3> $connection
+     * @param ConnectionInterface<AProtocol> $connection
      *
      * @throws Exception
      */


### PR DESCRIPTION
In future PHP Bolt library will change protocol classes and it won't be using chain of responsibility anymore. Each protocol version class won't be extending the previous one. It will change because changes between versions are not consistent. Therefore this php client needs to be prepared for this change.

I updated version check in the code with fn version_compare.