### PR TITLE
Implemented Address Resolving

### DIFF
--- a/src/Common/DNSAddressResolver.php
+++ b/src/Common/DNSAddressResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Common;
+
+use function array_filter;
+use function array_map;
+use function array_unique;
+use function array_values;
+use const DNS_A;
+use const DNS_AAAA;
+use function dns_get_record;
+use Laudis\Neo4j\Contracts\AddressResolverInterface;
+
+class DNSAddressResolver implements AddressResolverInterface
+{
+    /**
+     * @return iterable<string>
+     */
+    public function getAddresses(string $host): iterable
+    {
+        // By using the generator pattern we make sure to call the heavy DNS IO operations
+        // as late as possible
+        yield $host;
+
+        $records = dns_get_record($host, DNS_A | DNS_AAAA);
+        if (count($records) === 0) {
+            yield from $this->tryReverseLookup($host);
+        } else {
+            $records = array_map(static fn (array $x): string => $x['ip'] ?? '', $records);
+            $records = array_filter($records, static fn (string $x) => $x !== '');
+            yield from array_values(array_unique($records));
+        }
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    private function tryReverseLookup(string $host): iterable
+    {
+        $records = dns_get_record($host.'.in-addr.arpa');
+        if (count($records) !== 0) {
+            $records = array_map(static fn (array $x): string => $x['target'] ?? '', $records);
+            $records = array_filter($records, static fn (string $x) => $x !== '');
+            yield from array_values(array_unique($records));
+        }
+    }
+}

--- a/src/Common/DNSAddressResolver.php
+++ b/src/Common/DNSAddressResolver.php
@@ -31,11 +31,12 @@ class DNSAddressResolver implements AddressResolverInterface
         // as late as possible
         yield $host;
 
+        /** @var list<array{ip?: string|null}> $records */
         $records = dns_get_record($host, DNS_A | DNS_AAAA);
         if (count($records) === 0) {
             yield from $this->tryReverseLookup($host);
         } else {
-            $records = array_map(static fn (array $x): string => $x['ip'] ?? '', $records);
+            $records = array_map(static fn (array $x) => $x['ip'] ?? '', $records);
             $records = array_filter($records, static fn (string $x) => $x !== '');
             yield from array_values(array_unique($records));
         }
@@ -46,9 +47,10 @@ class DNSAddressResolver implements AddressResolverInterface
      */
     private function tryReverseLookup(string $host): iterable
     {
+        /** @var list<array{target?: string|null}> $records */
         $records = dns_get_record($host.'.in-addr.arpa');
         if (count($records) !== 0) {
-            $records = array_map(static fn (array $x): string => $x['target'] ?? '', $records);
+            $records = array_map(static fn (array $x) => $x['target'] ?? '', $records);
             $records = array_filter($records, static fn (string $x) => $x !== '');
             yield from array_values(array_unique($records));
         }

--- a/src/Contracts/AddressResolverInterface.php
+++ b/src/Contracts/AddressResolverInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Contracts;
+
+interface AddressResolverInterface
+{
+    /**
+     * Returns the addresses.
+     *
+     * @return iterable<string>
+     */
+    public function getAddresses(string $host): iterable;
+}

--- a/src/Neo4j/Neo4jConnectionPool.php
+++ b/src/Neo4j/Neo4jConnectionPool.php
@@ -28,6 +28,7 @@ use Laudis\Neo4j\Contracts\AddressResolverInterface;
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
 use Laudis\Neo4j\Contracts\ConnectionInterface;
 use Laudis\Neo4j\Contracts\ConnectionPoolInterface;
+use Laudis\Neo4j\Contracts\DriverInterface;
 use Laudis\Neo4j\Databags\SessionConfiguration;
 use Laudis\Neo4j\Enum\AccessMode;
 use Laudis\Neo4j\Enum\RoutingRoles;
@@ -41,7 +42,7 @@ use function time;
 /**
  * Connection pool for with auto client-side routing.
  *
- * @psalm-import-type BasicDriver from \Laudis\Neo4j\Contracts\DriverInterface
+ * @psalm-import-type BasicDriver from DriverInterface
  *
  * @implements ConnectionPoolInterface<V3>
  */
@@ -91,7 +92,7 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
                 }
             }
 
-            throw new RuntimeException(sprintf('Cannot connect to address: "%s". Addresses tried: "%s"', $uri->getHost(), implode('", "', $triedAddresses)));
+            throw new RuntimeException(sprintf('Cannot connect to host: "%s". Hosts tried: "%s"', $uri->getHost(), implode('", "', $triedAddresses)));
         }
 
         $server = $this->getNextServer($table, $config->getAccessMode()) ?? $uri;

--- a/src/Neo4j/Neo4jDriver.php
+++ b/src/Neo4j/Neo4jDriver.php
@@ -18,6 +18,7 @@ use function is_string;
 use Laudis\Neo4j\Authentication\Authenticate;
 use Laudis\Neo4j\Bolt\BoltConnectionPool;
 use Laudis\Neo4j\Bolt\Session;
+use Laudis\Neo4j\Common\DNSAddressResolver;
 use Laudis\Neo4j\Common\Uri;
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
 use Laudis\Neo4j\Contracts\DriverInterface;
@@ -35,7 +36,7 @@ use Psr\Http\Message\UriInterface;
  *
  * @implements DriverInterface<T>
  *
- * @psalm-import-type OGMResults from \Laudis\Neo4j\Formatter\OGMFormatter
+ * @psalm-import-type OGMResults from OGMFormatter
  */
 final class Neo4jDriver implements DriverInterface
 {
@@ -86,7 +87,7 @@ final class Neo4jDriver implements DriverInterface
             return new self(
                 $uri,
                 $authenticate ?? Authenticate::fromUrl($uri),
-                new Neo4jConnectionPool(new BoltConnectionPool($configuration)),
+                new Neo4jConnectionPool(new BoltConnectionPool($configuration), new DNSAddressResolver()),
                 $formatter,
             );
         }
@@ -94,7 +95,7 @@ final class Neo4jDriver implements DriverInterface
         return new self(
             $uri,
             $authenticate ?? Authenticate::fromUrl($uri),
-            new Neo4jConnectionPool(new BoltConnectionPool($configuration)),
+            new Neo4jConnectionPool(new BoltConnectionPool($configuration), new DNSAddressResolver()),
             OGMFormatter::create(),
         );
     }

--- a/tests/Unit/DNSAddressResolverTest.php
+++ b/tests/Unit/DNSAddressResolverTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Tests\Unit;
+
+use Laudis\Neo4j\Common\DNSAddressResolver;
+use PHPUnit\Framework\TestCase;
+
+class DNSAddressResolverTest extends TestCase
+{
+    private DNSAddressResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resolver = new DNSAddressResolver();
+    }
+
+    public function testResolverGhlenDotCom(): void
+    {
+        $records = [...$this->resolver->getAddresses('test.ghlen.com')];
+
+        $this->assertEqualsCanonicalizing(['test.ghlen.com', '123.123.123.123', '123.123.123.124'], $records);
+        $this->assertNotEmpty($records);
+        $this->assertEquals('test.ghlen.com', $records[0]);
+    }
+
+    public function testResolverGoogleDotComReverse(): void
+    {
+        $records = [...$this->resolver->getAddresses('8.8.8.8')];
+
+        $this->assertEqualsCanonicalizing(['8.8.8.8', 'dns.google'], $records);
+        $this->assertNotEmpty($records);
+        $this->assertEquals('8.8.8.8', $records[0]);
+    }
+
+    public function testBogus(): void
+    {
+        $this->assertEquals(['bogus'], [...$this->resolver->getAddresses('bogus')]);
+    }
+}


### PR DESCRIPTION
As discussed in #135 we are discussing connection resolving in HA setups who have multiple A or AAAA records.

After a long analysis and discussion, we've decided it only makes sense in the Neo4J scheme to do this. DNS resolving is an expensive IO operation and should only be used as a last resort, which is why the DNS Resolver implements a generator pattern to lazily evaluate the DNS queries at the latest possible moment.

It now only happens right before a routing table is being requested, and the provided URI doesn't work. In that case it will do some DNS queries and even a reverse lookup if needed. The assumption being that the data provided in the routing table is correct, and the failing queries will automatically be routed to other machines if one is down.

The only point of failure was before this update if you requested the routing table from a server that is down. This risk can now be mitigated through DNS configurations or through the solution proposed in #141 