### PR TITLE
Make `mixed` for CypherList/CypherMap explicit

### DIFF
--- a/src/Formatter/OGMFormatter.php
+++ b/src/Formatter/OGMFormatter.php
@@ -36,7 +36,7 @@ use function version_compare;
  *
  * @see https://neo4j.com/docs/driver-manual/current/cypher-workflow/#driver-type-mapping
  *
- * @psalm-type OGMTypes = string|int|float|bool|null|\Laudis\Neo4j\Types\Date|\Laudis\Neo4j\Types\DateTime|\Laudis\Neo4j\Types\Duration|\Laudis\Neo4j\Types\LocalDateTime|\Laudis\Neo4j\Types\LocalTime|\Laudis\Neo4j\Types\Time|\Laudis\Neo4j\Types\CypherList|\Laudis\Neo4j\Types\CypherMap|\Laudis\Neo4j\Types\Node|\Laudis\Neo4j\Types\Relationship|\Laudis\Neo4j\Types\Path|\Laudis\Neo4j\Types\Cartesian3DPoint|\Laudis\Neo4j\Types\CartesianPoint|\Laudis\Neo4j\Types\WGS84Point|\Laudis\Neo4j\Types\WGS843DPoint
+ * @psalm-type OGMTypes = string|int|float|bool|null|\Laudis\Neo4j\Types\Date|\Laudis\Neo4j\Types\DateTime|\Laudis\Neo4j\Types\Duration|\Laudis\Neo4j\Types\LocalDateTime|\Laudis\Neo4j\Types\LocalTime|\Laudis\Neo4j\Types\Time|\Laudis\Neo4j\Types\CypherList<mixed>|\Laudis\Neo4j\Types\CypherMap<mixed>|\Laudis\Neo4j\Types\Node|\Laudis\Neo4j\Types\Relationship|\Laudis\Neo4j\Types\Path|\Laudis\Neo4j\Types\Cartesian3DPoint|\Laudis\Neo4j\Types\CartesianPoint|\Laudis\Neo4j\Types\WGS84Point|\Laudis\Neo4j\Types\WGS843DPoint
  *
  * @psalm-type OGMResults = CypherList<CypherMap<OGMTypes>>
  *


### PR DESCRIPTION
Psalm automatically fills in `<mixed>` for the missing type parameter. However a lot of PHP projects use PHPStan which has no way of doing this. This makes it impossible to reuse the `OGMTypes` type and as a result makes it impossible to annotate types that match what Neo4j is providing. Being explicit about `mixed` makes the behaviour between Psalm and PHPStan the same.