### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.github                 export-ignore
+/.gitattributes          export-ignore
+/.gitignore              export-ignore
+/phpunit.xml.dist        export-ignore
+/psalm.xml.dist          export-ignore
+/tests                   export-ignore
+/.editorconfig           export-ignore
+/.php-cs-fixer.dist.php  export-ignore


### PR DESCRIPTION
This way the `tests` folder and etc do not end up being unnecessarily downloaded into the vendor folder when users install it on their projects.