### PR TITLE
[feat]: More precise handling of errors when verifying connectivity

### DIFF
--- a/docker-compose-neo4j-4.yml
+++ b/docker-compose-neo4j-4.yml
@@ -3,6 +3,7 @@ x-shared:
   NEO4J_AUTH: neo4j/testtest
   NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
   NEO4J_dbms_security_allow__csv__import__from__file__urls: "true"
+  NEO4J_dbms_security_auth__lock__time: 0s
   NEO4JLABS_PLUGINS: '["apoc"]'
 
 x-shared-cluster:

--- a/docker-compose-neo4j-4.yml
+++ b/docker-compose-neo4j-4.yml
@@ -31,7 +31,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        PHP_VERSION: ${PHP_VERSION}
+        PHP_VERSION: "${PHP_VERSION-8.1}"
     networks:
       - neo4j
     volumes:
@@ -46,7 +46,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        PHP_VERSION: ${PHP_VERSION}
+        PHP_VERSION: "${PHP_VERSION-8.1}"
         WITH_XDEBUG: true
     working_dir: /opt/project
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ x-definitions:
   x-shared-env:
     &common-env
     NEO4J_AUTH: neo4j/testtest
+    NEO4J_dbms_security_auth__lock__time: 0s
     NEO4J_PLUGINS: '["apoc"]'
   x-shared-cluster-env:
     &common-cluster-env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ x-definitions:
       context: .
       dockerfile: Dockerfile
       args:
-        PHP_VERSION: ${PHP_VERSION}
+        PHP_VERSION: "${PHP_VERSION-8.1}"
     volumes:
       - .:/opt/project
   x-common-cluster:

--- a/src/Bolt/BoltDriver.php
+++ b/src/Bolt/BoltDriver.php
@@ -15,7 +15,6 @@ namespace Laudis\Neo4j\Bolt;
 
 use Exception;
 
-use Psr\Log\LogLevel;
 use function is_string;
 
 use Laudis\Neo4j\Authentication\Authenticate;
@@ -29,7 +28,7 @@ use Laudis\Neo4j\Databags\DriverConfiguration;
 use Laudis\Neo4j\Databags\SessionConfiguration;
 use Laudis\Neo4j\Formatter\OGMFormatter;
 use Psr\Http\Message\UriInterface;
-use Throwable;
+use Psr\Log\LogLevel;
 
 /**
  * Drives a singular bolt connections.
@@ -105,7 +104,8 @@ final class BoltDriver implements DriverInterface
         try {
             GeneratorHelper::getReturnFromGenerator($this->pool->acquire($config));
         } catch (ConnectException $e) {
-            $this->pool->getLogger()->log(LogLevel::WARNING, 'Could not connect to server on URI ' . $this->parsedUrl->__toString(), ['error' => $e]);
+            $this->pool->getLogger()->log(LogLevel::WARNING, 'Could not connect to server on URI '.$this->parsedUrl->__toString(), ['error' => $e]);
+
             return false;
         }
 

--- a/src/Bolt/BoltDriver.php
+++ b/src/Bolt/BoltDriver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Bolt;
 
+use Bolt\error\ConnectException;
 use Exception;
 
 use function is_string;
@@ -104,7 +105,7 @@ final class BoltDriver implements DriverInterface
         try {
             GeneratorHelper::getReturnFromGenerator($this->pool->acquire($config));
         } catch (ConnectException $e) {
-            $this->pool->getLogger()->log(LogLevel::WARNING, 'Could not connect to server on URI '.$this->parsedUrl->__toString(), ['error' => $e]);
+            $this->pool->getLogger()?->log(LogLevel::WARNING, 'Could not connect to server on URI '.$this->parsedUrl->__toString(), ['error' => $e]);
 
             return false;
         }

--- a/src/Bolt/BoltDriver.php
+++ b/src/Bolt/BoltDriver.php
@@ -15,6 +15,7 @@ namespace Laudis\Neo4j\Bolt;
 
 use Exception;
 
+use Psr\Log\LogLevel;
 use function is_string;
 
 use Laudis\Neo4j\Authentication\Authenticate;
@@ -103,7 +104,8 @@ final class BoltDriver implements DriverInterface
         $config ??= SessionConfiguration::default();
         try {
             GeneratorHelper::getReturnFromGenerator($this->pool->acquire($config));
-        } catch (Throwable) {
+        } catch (ConnectException $e) {
+            $this->pool->getLogger()->log(LogLevel::WARNING, 'Could not connect to server on URI ' . $this->parsedUrl->__toString(), ['error' => $e]);
             return false;
         }
 

--- a/src/Common/DriverSetupManager.php
+++ b/src/Common/DriverSetupManager.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Common;
 
+use Bolt\error\ConnectException;
+use Psr\Log\LogLevel;
 use function array_key_exists;
 use function array_key_first;
 use function array_reduce;
@@ -144,7 +146,12 @@ class DriverSetupManager implements Countable
     {
         try {
             $this->getDriver($config, $alias);
-        } catch (RuntimeException) {
+        } catch (ConnectException $e) {
+            $this->getLogger()->log(
+                LogLevel::WARNING,
+                sprintf('Could not connect to server using alias (%s)', $alias ?? '<default>'),
+                ['exception' => $e]
+            );
             return false;
         }
 

--- a/src/Common/DriverSetupManager.php
+++ b/src/Common/DriverSetupManager.php
@@ -147,7 +147,7 @@ class DriverSetupManager implements Countable
         try {
             $this->getDriver($config, $alias);
         } catch (ConnectException $e) {
-            $this->getLogger()->log(
+            $this->getLogger()?->log(
                 LogLevel::WARNING,
                 sprintf('Could not connect to server using alias (%s)', $alias ?? '<default>'),
                 ['exception' => $e]

--- a/src/Common/DriverSetupManager.php
+++ b/src/Common/DriverSetupManager.php
@@ -13,12 +13,11 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Common;
 
-use Bolt\error\ConnectException;
-use Psr\Log\LogLevel;
 use function array_key_exists;
 use function array_key_first;
 use function array_reduce;
 
+use Bolt\error\ConnectException;
 use Countable;
 use InvalidArgumentException;
 use Laudis\Neo4j\Authentication\Authenticate;
@@ -31,6 +30,7 @@ use Laudis\Neo4j\DriverFactory;
 
 use const PHP_INT_MIN;
 
+use Psr\Log\LogLevel;
 use RuntimeException;
 use SplPriorityQueue;
 
@@ -152,6 +152,7 @@ class DriverSetupManager implements Countable
                 sprintf('Could not connect to server using alias (%s)', $alias ?? '<default>'),
                 ['exception' => $e]
             );
+
             return false;
         }
 

--- a/src/Neo4j/Neo4jConnectionPool.php
+++ b/src/Neo4j/Neo4jConnectionPool.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Neo4j;
 
-use Bolt\error\ConnectException;
 use function array_unique;
+
+use Bolt\error\ConnectException;
+
 use function count;
 
 use Exception;
@@ -51,9 +53,6 @@ use RuntimeException;
 
 use function sprintf;
 use function str_replace;
-
-use Throwable;
-
 use function time;
 
 /**

--- a/src/Neo4j/Neo4jConnectionPool.php
+++ b/src/Neo4j/Neo4jConnectionPool.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Neo4j;
 
+use Bolt\error\ConnectException;
 use function array_unique;
 use function count;
 
@@ -146,7 +147,7 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
                     /** @var BoltConnection $connection */
                     $connection = GeneratorHelper::getReturnFromGenerator($pool->acquire($config));
                     $table = $this->routingTable($connection, $config);
-                } catch (Throwable $e) {
+                } catch (ConnectException $e) {
                     // todo - once client side logging is implemented it must be conveyed here.
                     $latestError = $e;
                     continue; // We continue if something is wrong with the current server

--- a/src/Neo4j/Neo4jDriver.php
+++ b/src/Neo4j/Neo4jDriver.php
@@ -107,7 +107,7 @@ final class Neo4jDriver implements DriverInterface
         try {
             GeneratorHelper::getReturnFromGenerator($this->pool->acquire($config));
         } catch (ConnectException $e) {
-            $this->pool->getLogger()->log(LogLevel::WARNING, 'Could not connect to server on URI '.$this->parsedUrl->__toString(), ['error' => $e]);
+            $this->pool->getLogger()?->log(LogLevel::WARNING, 'Could not connect to server on URI '.$this->parsedUrl->__toString(), ['error' => $e]);
 
             return false;
         }

--- a/src/Neo4j/Neo4jDriver.php
+++ b/src/Neo4j/Neo4jDriver.php
@@ -16,7 +16,6 @@ namespace Laudis\Neo4j\Neo4j;
 use Bolt\error\ConnectException;
 use Exception;
 
-use Psr\Log\LogLevel;
 use function is_string;
 
 use Laudis\Neo4j\Authentication\Authenticate;
@@ -33,6 +32,7 @@ use Laudis\Neo4j\Databags\DriverConfiguration;
 use Laudis\Neo4j\Databags\SessionConfiguration;
 use Laudis\Neo4j\Formatter\OGMFormatter;
 use Psr\Http\Message\UriInterface;
+use Psr\Log\LogLevel;
 
 /**
  * Driver for auto client-side routing.
@@ -107,7 +107,7 @@ final class Neo4jDriver implements DriverInterface
         try {
             GeneratorHelper::getReturnFromGenerator($this->pool->acquire($config));
         } catch (ConnectException $e) {
-            $this->pool->getLogger()->log(LogLevel::WARNING, 'Could not connect to server on URI ' . $this->parsedUrl->__toString(), ['error' => $e]);
+            $this->pool->getLogger()->log(LogLevel::WARNING, 'Could not connect to server on URI '.$this->parsedUrl->__toString(), ['error' => $e]);
 
             return false;
         }

--- a/src/Neo4j/Neo4jDriver.php
+++ b/src/Neo4j/Neo4jDriver.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Neo4j;
 
+use Bolt\error\ConnectException;
 use Exception;
 
+use Psr\Log\LogLevel;
 use function is_string;
 
 use Laudis\Neo4j\Authentication\Authenticate;
@@ -31,7 +33,6 @@ use Laudis\Neo4j\Databags\DriverConfiguration;
 use Laudis\Neo4j\Databags\SessionConfiguration;
 use Laudis\Neo4j\Formatter\OGMFormatter;
 use Psr\Http\Message\UriInterface;
-use Throwable;
 
 /**
  * Driver for auto client-side routing.
@@ -105,7 +106,9 @@ final class Neo4jDriver implements DriverInterface
         $config ??= SessionConfiguration::default();
         try {
             GeneratorHelper::getReturnFromGenerator($this->pool->acquire($config));
-        } catch (Throwable) {
+        } catch (ConnectException $e) {
+            $this->pool->getLogger()->log(LogLevel::WARNING, 'Could not connect to server on URI ' . $this->parsedUrl->__toString(), ['error' => $e]);
+
             return false;
         }
 

--- a/tests/Integration/ClientIntegrationTest.php
+++ b/tests/Integration/ClientIntegrationTest.php
@@ -279,21 +279,27 @@ CYPHER,
             ->withDriver('http', 'http://localboast')
             ->build();
 
+        $exceptionThrownCount = 0;
         try {
-            self::assertFalse($client->verifyConnectivity('bolt'));
+            $client->verifyConnectivity('bolt');
         } catch (Exception $e) {
             self::assertInstanceOf(RuntimeException::class, $e);
+            ++$exceptionThrownCount;
         }
         try {
-            self::assertFalse($client->verifyConnectivity('neo4j'));
+            $client->verifyConnectivity('neo4j');
         } catch (Exception $e) {
             self::assertInstanceOf(RuntimeException::class, $e);
+            ++$exceptionThrownCount;
         }
         try {
-            self::assertFalse($client->verifyConnectivity('http'));
+            $client->verifyConnectivity('http');
         } catch (Exception $e) {
             self::assertInstanceOf(RuntimeException::class, $e);
+            ++$exceptionThrownCount;
         }
+
+        self::assertEquals(3, $exceptionThrownCount);
     }
 
     public function testValidConnectionCheck(): void

--- a/tests/Integration/ClientIntegrationTest.php
+++ b/tests/Integration/ClientIntegrationTest.php
@@ -41,17 +41,11 @@ final class ClientIntegrationTest extends EnvironmentAwareIntegrationTest
 {
     public function testDriverAuthFailureVerifyConnectivity(): void
     {
-        $connection = $_ENV['CONNECTION'] ?? false;
-        if (str_starts_with((string) $connection, 'http')) {
+        if (str_starts_with($this->uri->getScheme(), 'http')) {
             $this->markTestSkipped('HTTP does not support auth failure connectivity passing');
         }
 
-        if (!is_string($connection)) {
-            $connection = 'bolt://neo4j';
-        }
-
-        $uri = Uri::create($connection);
-        $uri = $uri->withUserInfo('neo4j', 'absolutelyonehundredpercentawrongpassword');
+        $uri = $this->uri->withUserInfo('neo4j', 'absolutelyonehundredpercentawrongpassword');
 
         /** @noinspection PhpUnhandledExceptionInspection */
         $conf = DriverConfiguration::default()->withLogger(LogLevel::DEBUG, $this->createMock(LoggerInterface::class));
@@ -71,17 +65,11 @@ final class ClientIntegrationTest extends EnvironmentAwareIntegrationTest
 
     public function testClientAuthFailureVerifyConnectivity(): void
     {
-        $connection = $_ENV['CONNECTION'] ?? false;
-        if (str_starts_with((string) $connection, 'http')) {
+        if (str_starts_with($this->uri->getScheme(), 'http')) {
             $this->markTestSkipped('HTTP does not support auth failure connectivity passing');
         }
 
-        if (!is_string($connection)) {
-            $connection = 'bolt://localhost';
-        }
-
-        $uri = Uri::create($connection);
-        $uri = $uri->withUserInfo('neo4j', 'absolutelyonehundredpercentawrongpassword');
+        $uri = $this->uri->withUserInfo('neo4j', 'absolutelyonehundredpercentawrongpassword');
 
         /** @noinspection PhpUnhandledExceptionInspection */
         $conf = DriverConfiguration::default()->withLogger(LogLevel::DEBUG, $this->createMock(LoggerInterface::class));

--- a/tests/Integration/ClientIntegrationTest.php
+++ b/tests/Integration/ClientIntegrationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Tests\Integration;
 
+use Exception;
 use InvalidArgumentException;
 use Laudis\Neo4j\Authentication\Authenticate;
 use Laudis\Neo4j\Basic\Driver;
@@ -46,7 +47,7 @@ final class ClientIntegrationTest extends EnvironmentAwareIntegrationTest
         }
 
         if (!is_string($connection)) {
-            $connection = 'bolt://localhost';
+            $connection = 'bolt://neo4j';
         }
 
         $uri = Uri::create($connection);
@@ -286,9 +287,21 @@ CYPHER,
             ->withDriver('http', 'http://localboast')
             ->build();
 
-        self::assertFalse($client->verifyConnectivity('bolt'));
-        self::assertFalse($client->verifyConnectivity('neo4j'));
-        self::assertFalse($client->verifyConnectivity('http'));
+        try {
+            self::assertFalse($client->verifyConnectivity('bolt'));
+        } catch (Exception $e) {
+            self::assertInstanceOf(RuntimeException::class, $e);
+        }
+        try {
+            self::assertFalse($client->verifyConnectivity('neo4j'));
+        } catch (Exception $e) {
+            self::assertInstanceOf(RuntimeException::class, $e);
+        }
+        try {
+            self::assertFalse($client->verifyConnectivity('http'));
+        } catch (Exception $e) {
+            self::assertInstanceOf(RuntimeException::class, $e);
+        }
     }
 
     public function testValidConnectionCheck(): void

--- a/tests/Integration/ClientIntegrationTest.php
+++ b/tests/Integration/ClientIntegrationTest.php
@@ -19,13 +19,17 @@ use Laudis\Neo4j\Basic\Driver;
 use Laudis\Neo4j\Bolt\BoltDriver;
 use Laudis\Neo4j\Bolt\ConnectionPool;
 use Laudis\Neo4j\ClientBuilder;
+use Laudis\Neo4j\Common\DriverSetupManager;
 use Laudis\Neo4j\Common\Uri;
 use Laudis\Neo4j\Contracts\DriverInterface;
 use Laudis\Neo4j\Contracts\TransactionInterface;
 use Laudis\Neo4j\Databags\DriverConfiguration;
+use Laudis\Neo4j\Databags\DriverSetup;
 use Laudis\Neo4j\Databags\SessionConfiguration;
 use Laudis\Neo4j\Databags\Statement;
+use Laudis\Neo4j\Databags\TransactionConfiguration;
 use Laudis\Neo4j\Exception\Neo4jException;
+use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
 use Laudis\Neo4j\Tests\EnvironmentAwareIntegrationTest;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -55,6 +59,45 @@ final class ClientIntegrationTest extends EnvironmentAwareIntegrationTest
         }
 
         $driver = Driver::create($uri, $conf);
+
+        $this->expectException(Neo4jException::class);
+        $this->expectExceptionMessage('Neo4j errors detected. First one with code "Neo.ClientError.Security.Unauthorized" and message "The client is unauthorized due to authentication failure."');
+        $driver->verifyConnectivity();
+    }
+
+    public function testClientAuthFailureVerifyConnectivity(): void
+    {
+        $connection = $_ENV['CONNECTION'] ?? false;
+        if (str_starts_with($connection, 'http')) {
+            $this->markTestSkipped('HTTP does not support auth failure connectivity passing');
+        }
+
+        if (!is_string($connection)) {
+            $connection = 'bolt://localhost';
+        }
+
+        $uri = Uri::create($connection);
+        $uri = $uri->withUserInfo('neo4j', 'absolutelyonehundredpercentawrongpassword');
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $conf = DriverConfiguration::default()->withLogger(LogLevel::DEBUG, $this->createMock(LoggerInterface::class));
+        $logger = $conf->getLogger();
+        if ($logger === null) {
+            throw new RuntimeException('Logger not set');
+        }
+
+        $client = (new ClientBuilder(
+            SessionConfiguration::create(),
+            TransactionConfiguration::create(),
+            (new DriverSetupManager(
+                SummarizedResultFormatter::create(),
+                $conf,
+            ))->withSetup(
+                new DriverSetup($uri, Authenticate::fromUrl($uri, $logger))
+            )
+        ))->build();
+
+        $driver = $client->getDriver(null);
 
         $this->expectException(Neo4jException::class);
         $this->expectExceptionMessage('Neo4j errors detected. First one with code "Neo.ClientError.Security.Unauthorized" and message "The client is unauthorized due to authentication failure."');

--- a/tests/Integration/ClientIntegrationTest.php
+++ b/tests/Integration/ClientIntegrationTest.php
@@ -21,7 +21,6 @@ use Laudis\Neo4j\Bolt\BoltDriver;
 use Laudis\Neo4j\Bolt\ConnectionPool;
 use Laudis\Neo4j\ClientBuilder;
 use Laudis\Neo4j\Common\DriverSetupManager;
-use Laudis\Neo4j\Common\Uri;
 use Laudis\Neo4j\Contracts\DriverInterface;
 use Laudis\Neo4j\Contracts\TransactionInterface;
 use Laudis\Neo4j\Databags\DriverConfiguration;
@@ -39,6 +38,12 @@ use RuntimeException;
 
 final class ClientIntegrationTest extends EnvironmentAwareIntegrationTest
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->driver->closeConnections();
+    }
+
     public function testDriverAuthFailureVerifyConnectivity(): void
     {
         if (str_starts_with($this->uri->getScheme(), 'http')) {
@@ -47,7 +52,6 @@ final class ClientIntegrationTest extends EnvironmentAwareIntegrationTest
 
         $uri = $this->uri->withUserInfo('neo4j', 'absolutelyonehundredpercentawrongpassword');
 
-        /** @noinspection PhpUnhandledExceptionInspection */
         $conf = DriverConfiguration::default()->withLogger(LogLevel::DEBUG, $this->createMock(LoggerInterface::class));
         $logger = $conf->getLogger();
         if ($logger === null) {
@@ -60,6 +64,7 @@ final class ClientIntegrationTest extends EnvironmentAwareIntegrationTest
         $this->expectExceptionMessage(
             'Neo4j errors detected. First one with code "Neo.ClientError.Security.Unauthorized" and message "The client is unauthorized due to authentication failure."'
         );
+
         $driver->verifyConnectivity();
     }
 
@@ -89,13 +94,12 @@ final class ClientIntegrationTest extends EnvironmentAwareIntegrationTest
             )
         ))->build();
 
-        $driver = $client->getDriver(null);
-
         $this->expectException(Neo4jException::class);
         $this->expectExceptionMessage(
             'Neo4j errors detected. First one with code "Neo.ClientError.Security.Unauthorized" and message "The client is unauthorized due to authentication failure."'
         );
-        $driver->verifyConnectivity();
+
+        $client->getDriver(null);
     }
 
     public function testDifferentAuth(): void


### PR DESCRIPTION
Currently, when we verify a connection, we catch any runtime exception.

This has led to confusing error handling, especially in more complex situations @exaby73 @AkshatSW.

When the connection can't be verified, we actually just want to check if we can reach the server. If any other error (e.g., Authentication errors) appears, we shouldn't handle it and let it bubble up so the end user is aware the connection is valid but some other client error happened.