### PR TITLE
 TypeCaster: unit tests, InvalidTypeCast, and tryToString refactor

### DIFF
--- a/src/Exception/InvalidTypeCast.php
+++ b/src/Exception/InvalidTypeCast.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Exception;
+
+use function get_debug_type;
+use function preg_match;
+
+use RuntimeException;
+
+final class InvalidTypeCast extends RuntimeException
+{
+    public function __construct(
+        mixed $value,
+        private readonly string $targetType,
+    ) {
+        $receivedType = get_debug_type($value);
+        $message = sprintf(
+            'Cannot cast %s to %s',
+            $receivedType,
+            $targetType
+        );
+        parent::__construct($message);
+    }
+
+    public function getReceivedType(): string
+    {
+        if (preg_match('/^Cannot cast (.+?) to /', $this->getMessage(), $m) && array_key_exists(1, $m)) {
+            return $m[1];
+        }
+
+        return 'unknown';
+    }
+
+    public function getTargetType(): string
+    {
+        return $this->targetType;
+    }
+}

--- a/src/TypeCaster.php
+++ b/src/TypeCaster.php
@@ -18,6 +18,7 @@ use function is_iterable;
 use function is_numeric;
 use function is_scalar;
 
+use Laudis\Neo4j\Exception\InvalidTypeCast;
 use Laudis\Neo4j\Types\CypherList;
 use Laudis\Neo4j\Types\CypherMap;
 use Stringable;
@@ -25,51 +26,65 @@ use Stringable;
 final class TypeCaster
 {
     /**
+     * @throws InvalidTypeCast
+     *
      * @pure
      */
-    public static function toString(mixed $value): ?string
+    public static function toString(mixed $value): string
     {
         if ($value === null || is_scalar($value) || $value instanceof Stringable) {
             return (string) $value;
         }
 
-        return null;
+        throw new InvalidTypeCast($value, 'string');
     }
 
     /**
+     * @throws InvalidTypeCast
+     *
      * @pure
      */
-    public static function toFloat(mixed $value): ?float
+    public static function toFloat(mixed $value): float
     {
         if (is_numeric($value) || is_bool($value)) {
             return (float) $value;
         }
 
-        $value = self::toString($value);
-
-        if (is_numeric($value)) {
-            return (float) $value;
+        try {
+            $stringValue = self::toString($value);
+        } catch (InvalidTypeCast) {
+            throw new InvalidTypeCast($value, 'float');
         }
 
-        return null;
+        if (is_numeric($stringValue)) {
+            return (float) $stringValue;
+        }
+
+        throw new InvalidTypeCast($value, 'float');
     }
 
     /**
+     * @throws InvalidTypeCast
+     *
      * @pure
      */
-    public static function toInt(mixed $value): ?int
+    public static function toInt(mixed $value): int
     {
         if (is_numeric($value) || is_bool($value)) {
             return (int) $value;
         }
 
-        $value = self::toString($value);
-
-        if (is_numeric($value)) {
-            return (int) $value;
+        try {
+            $stringValue = self::toString($value);
+        } catch (InvalidTypeCast) {
+            throw new InvalidTypeCast($value, 'int');
         }
 
-        return null;
+        if (is_numeric($stringValue)) {
+            return (int) $stringValue;
+        }
+
+        throw new InvalidTypeCast($value, 'int');
     }
 
     /**
@@ -83,21 +98,27 @@ final class TypeCaster
     }
 
     /**
+     * @throws InvalidTypeCast
+     *
      * @pure
      */
-    public static function toBool(mixed $value): ?bool
+    public static function toBool(mixed $value): bool
     {
         if (is_bool($value) || is_numeric($value)) {
             return (bool) $value;
         }
 
-        $value = self::toString($value);
-
-        if (is_numeric($value)) {
-            return (bool) $value;
+        try {
+            $stringValue = self::toString($value);
+        } catch (InvalidTypeCast) {
+            throw new InvalidTypeCast($value, 'bool');
         }
 
-        return null;
+        if (is_numeric($stringValue)) {
+            return (bool) $stringValue;
+        }
+
+        throw new InvalidTypeCast($value, 'bool');
     }
 
     /**
@@ -105,26 +126,30 @@ final class TypeCaster
      *
      * @param class-string<T> $class
      *
-     * @return T|null
+     * @throws InvalidTypeCast
+     *
+     * @return T
      *
      * @pure
      */
-    public static function toClass(mixed $value, string $class): ?object
+    public static function toClass(mixed $value, string $class): object
     {
         if (is_a($value, $class)) {
             /** @var T */
             return $value;
         }
 
-        return null;
+        throw new InvalidTypeCast($value, $class);
     }
 
     /**
+     * @throws InvalidTypeCast
+     *
      * @return list<mixed>
      *
      * @psalm-external-mutation-free
      */
-    public static function toArray(mixed $value): ?array
+    public static function toArray(mixed $value): array
     {
         if (is_iterable($value)) {
             $tbr = [];
@@ -137,32 +162,36 @@ final class TypeCaster
             return $tbr;
         }
 
-        return null;
+        throw new InvalidTypeCast($value, 'array');
     }
 
     /**
-     * @return CypherList<mixed>|null
+     * @throws InvalidTypeCast
+     *
+     * @return CypherList<mixed>
      *
      * @pure
      */
-    public static function toCypherList(mixed $value): ?CypherList
+    public static function toCypherList(mixed $value): CypherList
     {
         if (is_iterable($value)) {
             return CypherList::fromIterable($value);
         }
 
-        return null;
+        throw new InvalidTypeCast($value, CypherList::class);
     }
 
     /**
-     * @return CypherMap<mixed>|null
+     * @throws InvalidTypeCast
+     *
+     * @return CypherMap<mixed>
      */
-    public static function toCypherMap(mixed $value): ?CypherMap
+    public static function toCypherMap(mixed $value): CypherMap
     {
         if (is_iterable($value)) {
             return CypherMap::fromIterable($value);
         }
 
-        return null;
+        throw new InvalidTypeCast($value, CypherMap::class);
     }
 }

--- a/src/TypeCaster.php
+++ b/src/TypeCaster.php
@@ -16,13 +16,11 @@ namespace Laudis\Neo4j;
 use function is_a;
 use function is_iterable;
 use function is_numeric;
-use function is_object;
 use function is_scalar;
 
 use Laudis\Neo4j\Types\CypherList;
 use Laudis\Neo4j\Types\CypherMap;
-
-use function method_exists;
+use Stringable;
 
 final class TypeCaster
 {
@@ -31,7 +29,7 @@ final class TypeCaster
      */
     public static function toString(mixed $value): ?string
     {
-        if ($value === null || is_scalar($value) || (is_object($value) && method_exists($value, '__toString'))) {
+        if ($value === null || is_scalar($value) || $value instanceof Stringable) {
             return (string) $value;
         }
 
@@ -43,7 +41,12 @@ final class TypeCaster
      */
     public static function toFloat(mixed $value): ?float
     {
+        if (is_numeric($value) || is_bool($value)) {
+            return (float) $value;
+        }
+
         $value = self::toString($value);
+
         if (is_numeric($value)) {
             return (float) $value;
         }
@@ -56,8 +59,13 @@ final class TypeCaster
      */
     public static function toInt(mixed $value): ?int
     {
-        $value = self::toFloat($value);
-        if ($value !== null) {
+        if (is_numeric($value) || is_bool($value)) {
+            return (int) $value;
+        }
+
+        $value = self::toString($value);
+
+        if (is_numeric($value)) {
             return (int) $value;
         }
 
@@ -79,8 +87,13 @@ final class TypeCaster
      */
     public static function toBool(mixed $value): ?bool
     {
-        $value = self::toInt($value);
-        if ($value !== null) {
+        if (is_bool($value) || is_numeric($value)) {
+            return (bool) $value;
+        }
+
+        $value = self::toString($value);
+
+        if (is_numeric($value)) {
             return (bool) $value;
         }
 

--- a/src/TypeCaster.php
+++ b/src/TypeCaster.php
@@ -26,17 +26,30 @@ use Stringable;
 final class TypeCaster
 {
     /**
+     * @pure
+     */
+    private static function tryToString(mixed $value): ?string
+    {
+        if ($value === null || is_scalar($value) || $value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        return null;
+    }
+
+    /**
      * @throws InvalidTypeCast
      *
      * @pure
      */
     public static function toString(mixed $value): string
     {
-        if ($value === null || is_scalar($value) || $value instanceof Stringable) {
-            return (string) $value;
+        $result = self::tryToString($value);
+        if ($result === null) {
+            throw new InvalidTypeCast($value, 'string');
         }
 
-        throw new InvalidTypeCast($value, 'string');
+        return $result;
     }
 
     /**
@@ -50,17 +63,12 @@ final class TypeCaster
             return (float) $value;
         }
 
-        try {
-            $stringValue = self::toString($value);
-        } catch (InvalidTypeCast) {
+        $stringValue = self::tryToString($value);
+        if ($stringValue === null || !is_numeric($stringValue)) {
             throw new InvalidTypeCast($value, 'float');
         }
 
-        if (is_numeric($stringValue)) {
-            return (float) $stringValue;
-        }
-
-        throw new InvalidTypeCast($value, 'float');
+        return (float) $stringValue;
     }
 
     /**
@@ -74,17 +82,12 @@ final class TypeCaster
             return (int) $value;
         }
 
-        try {
-            $stringValue = self::toString($value);
-        } catch (InvalidTypeCast) {
+        $stringValue = self::tryToString($value);
+        if ($stringValue === null || !is_numeric($stringValue)) {
             throw new InvalidTypeCast($value, 'int');
         }
 
-        if (is_numeric($stringValue)) {
-            return (int) $stringValue;
-        }
-
-        throw new InvalidTypeCast($value, 'int');
+        return (int) $stringValue;
     }
 
     /**
@@ -108,17 +111,12 @@ final class TypeCaster
             return (bool) $value;
         }
 
-        try {
-            $stringValue = self::toString($value);
-        } catch (InvalidTypeCast) {
+        $stringValue = self::tryToString($value);
+        if ($stringValue === null || !is_numeric($stringValue)) {
             throw new InvalidTypeCast($value, 'bool');
         }
 
-        if (is_numeric($stringValue)) {
-            return (bool) $stringValue;
-        }
-
-        throw new InvalidTypeCast($value, 'bool');
+        return (bool) $stringValue;
     }
 
     /**

--- a/src/Types/CypherList.php
+++ b/src/Types/CypherList.php
@@ -23,7 +23,6 @@ use function is_callable;
 
 use Iterator;
 use Laudis\Neo4j\Contracts\CypherSequence;
-use Laudis\Neo4j\Exception\RuntimeTypeException;
 use Laudis\Neo4j\TypeCaster;
 use OutOfBoundsException;
 
@@ -151,46 +150,22 @@ class CypherList implements CypherSequence, Iterator, ArrayAccess
 
     public function getAsString(int $key): string
     {
-        $value = $this->get($key);
-        $tbr = TypeCaster::toString($value);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, 'string');
-        }
-
-        return $tbr;
+        return TypeCaster::toString($this->get($key));
     }
 
     public function getAsInt(int $key): int
     {
-        $value = $this->get($key);
-        $tbr = TypeCaster::toInt($value);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, 'int');
-        }
-
-        return $tbr;
+        return TypeCaster::toInt($this->get($key));
     }
 
     public function getAsFloat(int $key): float
     {
-        $value = $this->get($key);
-        $tbr = TypeCaster::toFloat($value);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, 'float');
-        }
-
-        return $tbr;
+        return TypeCaster::toFloat($this->get($key));
     }
 
     public function getAsBool(int $key): bool
     {
-        $value = $this->get($key);
-        $tbr = TypeCaster::toBool($value);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, 'bool');
-        }
-
-        return $tbr;
+        return TypeCaster::toBool($this->get($key));
     }
 
     /**
@@ -213,13 +188,7 @@ class CypherList implements CypherSequence, Iterator, ArrayAccess
      */
     public function getAsObject(int $key, string $class): object
     {
-        $value = $this->get($key);
-        $tbr = TypeCaster::toClass($value, $class);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, $class);
-        }
-
-        return $tbr;
+        return TypeCaster::toClass($this->get($key), $class);
     }
 
     /**
@@ -257,13 +226,7 @@ class CypherList implements CypherSequence, Iterator, ArrayAccess
      */
     public function getAsCypherMap(int $key): CypherMap
     {
-        $value = $this->get($key);
-        $tbr = TypeCaster::toCypherMap($value);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, CypherMap::class);
-        }
-
-        return $tbr;
+        return TypeCaster::toCypherMap($this->get($key));
     }
 
     /**
@@ -271,13 +234,7 @@ class CypherList implements CypherSequence, Iterator, ArrayAccess
      */
     public function getAsCypherList(int $key): CypherList
     {
-        $value = $this->get($key);
-        $tbr = TypeCaster::toCypherList($value);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, CypherList::class);
-        }
-
-        return $tbr;
+        return TypeCaster::toCypherList($this->get($key));
     }
 
     public function getAsDate(int $key): Date

--- a/src/Types/CypherMap.php
+++ b/src/Types/CypherMap.php
@@ -22,7 +22,6 @@ use Generator;
 use Iterator;
 use Laudis\Neo4j\Contracts\CypherSequence;
 use Laudis\Neo4j\Databags\Pair;
-use Laudis\Neo4j\Exception\RuntimeTypeException;
 use Laudis\Neo4j\TypeCaster;
 use OutOfBoundsException;
 use stdClass;
@@ -360,62 +359,22 @@ final class CypherMap implements CypherSequence, ArrayAccess, Iterator
 
     public function getAsString(string $key): string
     {
-        if (func_num_args() === 1) {
-            $value = $this->get($key);
-        } else {
-            $value = $this->get($key);
-        }
-        $tbr = TypeCaster::toString($value);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, 'string');
-        }
-
-        return $tbr;
+        return TypeCaster::toString($this->get($key));
     }
 
     public function getAsInt(string $key): int
     {
-        if (func_num_args() === 1) {
-            $value = $this->get($key);
-        } else {
-            $value = $this->get($key);
-        }
-        $tbr = TypeCaster::toInt($value);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, 'int');
-        }
-
-        return $tbr;
+        return TypeCaster::toInt($this->get($key));
     }
 
     public function getAsFloat(string $key): float
     {
-        if (func_num_args() === 1) {
-            $value = $this->get($key);
-        } else {
-            $value = $this->get($key);
-        }
-        $tbr = TypeCaster::toFloat($value);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, 'float');
-        }
-
-        return $tbr;
+        return TypeCaster::toFloat($this->get($key));
     }
 
     public function getAsBool(string $key): bool
     {
-        if (func_num_args() === 1) {
-            $value = $this->get($key);
-        } else {
-            $value = $this->get($key);
-        }
-        $tbr = TypeCaster::toBool($value);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, 'bool');
-        }
-
-        return $tbr;
+        return TypeCaster::toBool($this->get($key));
     }
 
     /**
@@ -440,13 +399,7 @@ final class CypherMap implements CypherSequence, ArrayAccess, Iterator
      */
     public function getAsObject(string $key, string $class): object
     {
-        $value = $this->get($key);
-        $tbr = TypeCaster::toClass($value, $class);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, $class);
-        }
-
-        return $tbr;
+        return TypeCaster::toClass($this->get($key), $class);
     }
 
     /**
@@ -466,13 +419,7 @@ final class CypherMap implements CypherSequence, ArrayAccess, Iterator
      */
     public function getAsCypherMap(string $key): CypherMap
     {
-        $value = $this->get($key);
-        $tbr = TypeCaster::toCypherMap($value);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, self::class);
-        }
-
-        return $tbr;
+        return TypeCaster::toCypherMap($this->get($key));
     }
 
     /**
@@ -480,13 +427,7 @@ final class CypherMap implements CypherSequence, ArrayAccess, Iterator
      */
     public function getAsCypherList(string $key): CypherList
     {
-        $value = $this->get($key);
-        $tbr = TypeCaster::toCypherList($value);
-        if ($tbr === null) {
-            throw new RuntimeTypeException($value, CypherList::class);
-        }
-
-        return $tbr;
+        return TypeCaster::toCypherList($this->get($key));
     }
 
     public function getAsDate(string $key): Date

--- a/tests/Unit/CypherMapTest.php
+++ b/tests/Unit/CypherMapTest.php
@@ -23,7 +23,7 @@ use function json_encode;
 use const JSON_THROW_ON_ERROR;
 
 use Laudis\Neo4j\Databags\Pair;
-use Laudis\Neo4j\Exception\RuntimeTypeException;
+use Laudis\Neo4j\Exception\InvalidTypeCast;
 use Laudis\Neo4j\Types\CypherList;
 use Laudis\Neo4j\Types\CypherMap;
 use OutOfBoundsException;
@@ -470,7 +470,7 @@ final class CypherMapTest extends TestCase
 
         self::assertEquals('', $map->getAsString('a'));
 
-        $this->expectException(RuntimeTypeException::class);
+        $this->expectException(InvalidTypeCast::class);
         $map->getAsCartesian3DPoint('a');
     }
 

--- a/tests/Unit/TypeCasterTest.php
+++ b/tests/Unit/TypeCasterTest.php
@@ -15,6 +15,8 @@ namespace Laudis\Neo4j\Tests\Unit;
 
 use ArrayIterator;
 use Generator;
+use InvalidArgumentException;
+use Laudis\Neo4j\Exception\InvalidTypeCast;
 use Laudis\Neo4j\TypeCaster;
 use Laudis\Neo4j\Types\CypherList;
 use Laudis\Neo4j\Types\CypherMap;
@@ -24,71 +26,430 @@ use Stringable;
 
 final class TypeCasterTest extends TestCase
 {
-    private stdClass $stdObj;
-
-    private object $stringable;
-
-    public function setUp(): void
+    /**
+     * Complete coverage: every input type × every cast method.
+     * When a cast isn't possible, expected is null (invalid case).
+     *
+     * @return iterable<string, array{input: mixed, method: string, expected: mixed, class?: string}>
+     */
+    public static function provideCastMatrix(): iterable
     {
-        parent::setUp();
-
-        $this->stdObj = new stdClass();
-        $this->stringable = new class implements Stringable {
+        $stringable = new class implements Stringable {
             public function __toString(): string
             {
                 return 'stringable-value';
             }
         };
+        $stringableNumeric = new class implements Stringable {
+            public function __toString(): string
+            {
+                return '42';
+            }
+        };
+        $stringableNumericFloat = new class implements Stringable {
+            public function __toString(): string
+            {
+                return '42.5';
+            }
+        };
+        $stdObj = new stdClass();
+
+        $inputs = [
+            'null' => null,
+            'int' => 42,
+            'int_zero' => 0,
+            'int_one' => 1,
+            'float' => 3.14,
+            'float_zero' => 0.0,
+            'bool_true' => true,
+            'bool_false' => false,
+            'string_empty' => '',
+            'string_nonempty' => 'hello',
+            'string_numeric_int' => '123',
+            'string_numeric_float' => '99.9',
+            'string_one' => '1',
+            'string_zero' => '0',
+            'string_non_numeric' => 'abc',
+            'string_true' => 'true',
+            'string_forty_two' => '42',
+            'stringable' => $stringable,
+            'stringable_numeric' => $stringableNumeric,
+            'stringable_numeric_float' => $stringableNumericFloat,
+            'array_indexed' => [1, 2, 3],
+            'array_associative' => ['a' => 1, 'b' => 2],
+            'array_empty' => [],
+            'ArrayIterator' => new ArrayIterator([10, 20]),
+            'Generator' => null, // Created fresh per row (consumable)
+            'CypherList' => new CypherList([1, 2, 3]),
+            'CypherMap' => new CypherMap(['x' => 1, 'y' => 2]),
+            'stdClass' => $stdObj,
+        ];
+
+        $matrix = self::getExpectedMatrix($stringable, $stringableNumeric, $stringableNumericFloat, $stdObj);
+
+        foreach ($inputs as $inputName => $inputValue) {
+            foreach ($matrix as $method => $expectations) {
+                $expected = $expectations[$inputName] ?? null;
+                $key = $inputName.'->'.$method;
+
+                // Generator must be fresh per test (consumable once)
+                $actualInput = $inputName === 'Generator'
+                    ? (static function (): Generator {
+                        yield 1;
+                        yield 2;
+                    })()
+                    : $inputValue;
+
+                $row = [
+                    'input' => $actualInput,
+                    'method' => $method,
+                    'expected' => $expected,
+                ];
+
+                if ($method === 'toClass') {
+                    $row['class'] = $expectations['_class'][$inputName] ?? stdClass::class;
+                }
+
+                yield $key => $row;
+            }
+        }
     }
 
-    public function testToStringWithNull(): void
-    {
-        self::assertSame('', TypeCaster::toString(null));
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private static function getExpectedMatrix(
+        object $stringable,
+        object $stringableNumeric,
+        object $stringableNumericFloat,
+        stdClass $stdObj,
+    ): array {
+        return [
+            'toString' => [
+                'null' => '',
+                'int' => '42',
+                'int_zero' => '0',
+                'int_one' => '1',
+                'float' => '3.14',
+                'float_zero' => '0',
+                'bool_true' => '1',
+                'bool_false' => '',
+                'string_empty' => '',
+                'string_nonempty' => 'hello',
+                'string_numeric_int' => '123',
+                'string_numeric_float' => '99.9',
+                'string_one' => '1',
+                'string_zero' => '0',
+                'string_non_numeric' => 'abc',
+                'string_true' => 'true',
+                'string_forty_two' => '42',
+                'stringable' => 'stringable-value',
+                'stringable_numeric' => '42',
+                'stringable_numeric_float' => '42.5',
+                'array_indexed' => null,
+                'array_associative' => null,
+                'array_empty' => null,
+                'ArrayIterator' => null,
+                'Generator' => null,
+                'CypherList' => null,
+                'CypherMap' => null,
+                'stdClass' => null,
+            ],
+            'toInt' => [
+                'null' => null,
+                'int' => 42,
+                'int_zero' => 0,
+                'int_one' => 1,
+                'float' => 3,
+                'float_zero' => 0,
+                'bool_true' => 1,
+                'bool_false' => 0,
+                'string_empty' => null,
+                'string_nonempty' => null,
+                'string_numeric_int' => 123,
+                'string_numeric_float' => 99,
+                'string_one' => 1,
+                'string_zero' => 0,
+                'string_non_numeric' => null,
+                'string_true' => null,
+                'string_forty_two' => 42,
+                'stringable' => null,
+                'stringable_numeric' => 42,
+                'stringable_numeric_float' => 42,
+                'array_indexed' => null,
+                'array_associative' => null,
+                'array_empty' => null,
+                'ArrayIterator' => null,
+                'Generator' => null,
+                'CypherList' => null,
+                'CypherMap' => null,
+                'stdClass' => null,
+            ],
+            'toFloat' => [
+                'null' => null,
+                'int' => 42.0,
+                'int_zero' => 0.0,
+                'int_one' => 1.0,
+                'float' => 3.14,
+                'float_zero' => 0.0,
+                'bool_true' => 1.0,
+                'bool_false' => 0.0,
+                'string_empty' => null,
+                'string_nonempty' => null,
+                'string_numeric_int' => 123.0,
+                'string_numeric_float' => 99.9,
+                'string_one' => 1.0,
+                'string_zero' => 0.0,
+                'string_non_numeric' => null,
+                'string_true' => null,
+                'string_forty_two' => 42.0,
+                'stringable' => null,
+                'stringable_numeric' => 42.0,
+                'stringable_numeric_float' => 42.5,
+                'array_indexed' => null,
+                'array_associative' => null,
+                'array_empty' => null,
+                'ArrayIterator' => null,
+                'Generator' => null,
+                'CypherList' => null,
+                'CypherMap' => null,
+                'stdClass' => null,
+            ],
+            'toBool' => [
+                'null' => null,
+                'int' => true,
+                'int_zero' => false,
+                'int_one' => true,
+                'float' => true,
+                'float_zero' => false,
+                'bool_true' => true,
+                'bool_false' => false,
+                'string_empty' => null,
+                'string_nonempty' => null,
+                'string_numeric_int' => true,
+                'string_numeric_float' => true,
+                'string_one' => true,
+                'string_zero' => false,
+                'string_non_numeric' => null,
+                'string_true' => null,
+                'string_forty_two' => true,
+                'stringable' => null,
+                'stringable_numeric' => true,
+                'stringable_numeric_float' => true,
+                'array_indexed' => null,
+                'array_associative' => null,
+                'array_empty' => null,
+                'ArrayIterator' => null,
+                'Generator' => null,
+                'CypherList' => null,
+                'CypherMap' => null,
+                'stdClass' => null,
+            ],
+            'toClass' => [
+                '_class' => [
+                    'null' => stdClass::class,
+                    'int' => stdClass::class,
+                    'int_zero' => stdClass::class,
+                    'int_one' => stdClass::class,
+                    'float' => stdClass::class,
+                    'float_zero' => stdClass::class,
+                    'bool_true' => stdClass::class,
+                    'bool_false' => stdClass::class,
+                    'string_empty' => stdClass::class,
+                    'string_nonempty' => stdClass::class,
+                    'string_numeric_int' => stdClass::class,
+                    'string_numeric_float' => stdClass::class,
+                    'string_one' => stdClass::class,
+                    'string_zero' => stdClass::class,
+                    'string_non_numeric' => stdClass::class,
+                    'string_true' => stdClass::class,
+                    'string_forty_two' => stdClass::class,
+                    'stringable' => Stringable::class,
+                    'stringable_numeric' => Stringable::class,
+                    'stringable_numeric_float' => Stringable::class,
+                    'array_indexed' => stdClass::class,
+                    'array_associative' => stdClass::class,
+                    'array_empty' => stdClass::class,
+                    'ArrayIterator' => stdClass::class,
+                    'Generator' => stdClass::class,
+                    'CypherList' => stdClass::class,
+                    'CypherMap' => stdClass::class,
+                    'stdClass' => stdClass::class,
+                ],
+                'null' => null,
+                'int' => null,
+                'int_zero' => null,
+                'int_one' => null,
+                'float' => null,
+                'float_zero' => null,
+                'bool_true' => null,
+                'bool_false' => null,
+                'string_empty' => null,
+                'string_nonempty' => null,
+                'string_numeric_int' => null,
+                'string_numeric_float' => null,
+                'string_one' => null,
+                'string_zero' => null,
+                'string_non_numeric' => null,
+                'string_true' => null,
+                'string_forty_two' => null,
+                'stringable' => $stringable,
+                'stringable_numeric' => $stringableNumeric,
+                'stringable_numeric_float' => $stringableNumericFloat,
+                'array_indexed' => null,
+                'array_associative' => null,
+                'array_empty' => null,
+                'ArrayIterator' => null,
+                'Generator' => null,
+                'CypherList' => null,
+                'CypherMap' => null,
+                'stdClass' => $stdObj,
+            ],
+            'toArray' => [
+                'null' => null,
+                'int' => null,
+                'int_zero' => null,
+                'int_one' => null,
+                'float' => null,
+                'float_zero' => null,
+                'bool_true' => null,
+                'bool_false' => null,
+                'string_empty' => null,
+                'string_nonempty' => null,
+                'string_numeric_int' => null,
+                'string_numeric_float' => null,
+                'string_one' => null,
+                'string_zero' => null,
+                'string_non_numeric' => null,
+                'string_true' => null,
+                'string_forty_two' => null,
+                'stringable' => null,
+                'stringable_numeric' => null,
+                'stringable_numeric_float' => null,
+                'array_indexed' => [1, 2, 3],
+                'array_associative' => [1, 2],
+                'array_empty' => [],
+                'ArrayIterator' => [10, 20],
+                'Generator' => [1, 2],
+                'CypherList' => [1, 2, 3],
+                'CypherMap' => [1, 2],
+                'stdClass' => null,
+            ],
+            'toCypherList' => [
+                'null' => null,
+                'int' => null,
+                'int_zero' => null,
+                'int_one' => null,
+                'float' => null,
+                'float_zero' => null,
+                'bool_true' => null,
+                'bool_false' => null,
+                'string_empty' => null,
+                'string_nonempty' => null,
+                'string_numeric_int' => null,
+                'string_numeric_float' => null,
+                'string_one' => null,
+                'string_zero' => null,
+                'string_non_numeric' => null,
+                'string_true' => null,
+                'string_forty_two' => null,
+                'stringable' => null,
+                'stringable_numeric' => null,
+                'stringable_numeric_float' => null,
+                'array_indexed' => [1, 2, 3],
+                'array_associative' => [1, 2],
+                'array_empty' => [],
+                'ArrayIterator' => [10, 20],
+                'Generator' => [1, 2],
+                'CypherList' => [1, 2, 3],
+                'CypherMap' => [1, 2],
+                'stdClass' => null,
+            ],
+            'toCypherMap' => [
+                'null' => null,
+                'int' => null,
+                'int_zero' => null,
+                'int_one' => null,
+                'float' => null,
+                'float_zero' => null,
+                'bool_true' => null,
+                'bool_false' => null,
+                'string_empty' => null,
+                'string_nonempty' => null,
+                'string_numeric_int' => null,
+                'string_numeric_float' => null,
+                'string_one' => null,
+                'string_zero' => null,
+                'string_non_numeric' => null,
+                'string_true' => null,
+                'string_forty_two' => null,
+                'stringable' => null,
+                'stringable_numeric' => null,
+                'stringable_numeric_float' => null,
+                'array_indexed' => ['0' => 1, '1' => 2, '2' => 3],
+                'array_associative' => ['a' => 1, 'b' => 2],
+                'array_empty' => [],
+                'ArrayIterator' => ['0' => 10, '1' => 20],
+                'Generator' => ['0' => 1, '1' => 2],
+                'CypherList' => ['0' => 1, '1' => 2, '2' => 3],
+                'CypherMap' => ['x' => 1, 'y' => 2],
+                'stdClass' => null,
+            ],
+        ];
     }
 
-    public function testToStringWithInt(): void
+    /**
+     * @dataProvider provideCastMatrix
+     */
+    public function testCastMatrix(mixed $input, string $method, mixed $expected, ?string $class = null): void
     {
-        self::assertSame('42', TypeCaster::toString(42));
-    }
+        if ($expected === null) {
+            $this->expectException(InvalidTypeCast::class);
+        }
 
-    public function testToStringWithFloat(): void
-    {
-        self::assertSame('3.14', TypeCaster::toString(3.14));
-    }
+        /** @var class-string $classString */
+        $classString = $class ?? stdClass::class;
+        $result = match ($method) {
+            'toString' => TypeCaster::toString($input),
+            'toInt' => TypeCaster::toInt($input),
+            'toFloat' => TypeCaster::toFloat($input),
+            'toBool' => TypeCaster::toBool($input),
+            'toClass' => TypeCaster::toClass($input, $classString),
+            'toArray' => TypeCaster::toArray($input),
+            'toCypherList' => TypeCaster::toCypherList($input),
+            'toCypherMap' => TypeCaster::toCypherMap($input),
+            default => throw new InvalidArgumentException("Unknown method: {$method}"),
+        };
 
-    public function testToStringWithBoolTrue(): void
-    {
-        self::assertSame('1', TypeCaster::toString(true));
-    }
+        if ($expected === null) {
+            return;
+        }
 
-    public function testToStringWithBoolFalse(): void
-    {
-        self::assertSame('', TypeCaster::toString(false));
-    }
+        if ($method === 'toCypherList') {
+            self::assertInstanceOf(CypherList::class, $result);
+            self::assertEquals($expected, $result->toArray());
 
-    public function testToStringWithString(): void
-    {
-        self::assertSame('hello', TypeCaster::toString('hello'));
-    }
+            return;
+        }
 
-    public function testToStringWithStringEmpty(): void
-    {
-        self::assertSame('', TypeCaster::toString(''));
-    }
+        if ($method === 'toCypherMap') {
+            self::assertInstanceOf(CypherMap::class, $result);
+            self::assertEquals($expected, $result->toArray());
 
-    public function testToStringWithStringable(): void
-    {
-        self::assertSame('stringable-value', TypeCaster::toString($this->stringable));
-    }
+            return;
+        }
 
-    public function testToStringWithArrayReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toString([1, 2, 3]));
-    }
+        if ($method === 'toClass') {
+            self::assertSame($expected, $result);
 
-    public function testToStringWithObjectReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toString($this->stdObj));
+            return;
+        }
+
+        if (is_int($expected) || is_bool($expected)) {
+            self::assertSame($expected, $result);
+        } else {
+            self::assertEquals($expected, $result);
+        }
     }
 
     public function testToNull(): void
@@ -96,356 +457,14 @@ final class TypeCasterTest extends TestCase
         self::assertNull(TypeCaster::toNull());
     }
 
-    public function testToIntWithNull(): void
+    /**
+     * toClass with wrong class throws InvalidTypeCast.
+     */
+    public function testToClassWithWrongClassThrowsInvalidTypeCast(): void
     {
-        self::assertNull(TypeCaster::toInt(null));
-    }
-
-    public function testToIntWithInt(): void
-    {
-        self::assertSame(42, TypeCaster::toInt(42));
-    }
-
-    public function testToIntWithFloat(): void
-    {
-        self::assertSame(3, TypeCaster::toInt(3.14));
-    }
-
-    public function testToIntWithStringNumeric(): void
-    {
-        self::assertSame(123, TypeCaster::toInt('123'));
-    }
-
-    public function testToIntWithBoolTrue(): void
-    {
-        self::assertSame(1, TypeCaster::toInt(true));
-    }
-
-    public function testToIntWithBoolFalse(): void
-    {
-        self::assertSame(0, TypeCaster::toInt(false));
-    }
-
-    public function testToIntWithStringableNumeric(): void
-    {
-        $stringable = new class implements Stringable {
-            public function __toString(): string
-            {
-                return '42';
-            }
-        };
-        self::assertSame(42, TypeCaster::toInt($stringable));
-    }
-
-    public function testToIntWithStringNonNumericReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toInt('abc'));
-    }
-
-    public function testToIntWithArrayReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toInt([1, 2, 3]));
-    }
-
-    public function testToFloatWithNull(): void
-    {
-        self::assertNull(TypeCaster::toFloat(null));
-    }
-
-    public function testToFloatWithInt(): void
-    {
-        self::assertSame(42.0, TypeCaster::toFloat(42));
-    }
-
-    public function testToFloatWithFloat(): void
-    {
-        self::assertSame(3.14, TypeCaster::toFloat(3.14));
-    }
-
-    public function testToFloatWithStringNumeric(): void
-    {
-        self::assertSame(99.9, TypeCaster::toFloat('99.9'));
-    }
-
-    public function testToFloatWithBoolTrue(): void
-    {
-        self::assertSame(1.0, TypeCaster::toFloat(true));
-    }
-
-    public function testToFloatWithBoolFalse(): void
-    {
-        self::assertSame(0.0, TypeCaster::toFloat(false));
-    }
-
-    public function testToFloatWithStringableNumeric(): void
-    {
-        $stringable = new class implements Stringable {
-            public function __toString(): string
-            {
-                return '42.5';
-            }
-        };
-        self::assertSame(42.5, TypeCaster::toFloat($stringable));
-    }
-
-    public function testToFloatWithStringNonNumericReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toFloat('abc'));
-    }
-
-    public function testToFloatWithArrayReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toFloat([1, 2, 3]));
-    }
-
-    public function testToBoolWithNull(): void
-    {
-        self::assertNull(TypeCaster::toBool(null));
-    }
-
-    public function testToBoolWithTrue(): void
-    {
-        self::assertTrue(TypeCaster::toBool(true));
-    }
-
-    public function testToBoolWithFalse(): void
-    {
-        self::assertFalse(TypeCaster::toBool(false));
-    }
-
-    public function testToBoolWithIntOne(): void
-    {
-        self::assertTrue(TypeCaster::toBool(1));
-    }
-
-    public function testToBoolWithIntZero(): void
-    {
-        self::assertFalse(TypeCaster::toBool(0));
-    }
-
-    public function testToBoolWithStringOne(): void
-    {
-        self::assertTrue(TypeCaster::toBool('1'));
-    }
-
-    public function testToBoolWithStringZero(): void
-    {
-        self::assertFalse(TypeCaster::toBool('0'));
-    }
-
-    public function testToBoolWithStringNonNumericReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toBool('true'));
-    }
-
-    public function testToBoolWithArrayReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toBool([1, 2, 3]));
-    }
-
-    public function testToClassWithMatchingClass(): void
-    {
-        self::assertSame($this->stdObj, TypeCaster::toClass($this->stdObj, stdClass::class));
-    }
-
-    public function testToClassWithWrongClass(): void
-    {
-        self::assertNull(TypeCaster::toClass($this->stdObj, Stringable::class));
-    }
-
-    public function testToClassWithStringableInstance(): void
-    {
-        self::assertSame($this->stringable, TypeCaster::toClass($this->stringable, Stringable::class));
-    }
-
-    public function testToClassWithStringReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toClass('hello', stdClass::class));
-    }
-
-    public function testToClassWithIntReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toClass(42, stdClass::class));
-    }
-
-    public function testToClassWithNullReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toClass(null, stdClass::class));
-    }
-
-    public function testToClassWithArrayReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toClass([], stdClass::class));
-    }
-
-    public function testToArrayWithArray(): void
-    {
-        self::assertEquals([1, 2, 3], TypeCaster::toArray([1, 2, 3]));
-    }
-
-    public function testToArrayWithAssociativeArray(): void
-    {
-        self::assertEquals([1, 2], TypeCaster::toArray(['a' => 1, 'b' => 2]));
-    }
-
-    public function testToArrayWithEmptyArray(): void
-    {
-        self::assertEquals([], TypeCaster::toArray([]));
-    }
-
-    public function testToArrayWithIterator(): void
-    {
-        self::assertEquals([10, 20], TypeCaster::toArray(new ArrayIterator([10, 20])));
-    }
-
-    public function testToArrayWithCypherList(): void
-    {
-        self::assertEquals([1, 2, 3], TypeCaster::toArray(new CypherList([1, 2, 3])));
-    }
-
-    public function testToArrayWithCypherMap(): void
-    {
-        self::assertEquals([1, 2], TypeCaster::toArray(new CypherMap(['x' => 1, 'y' => 2])));
-    }
-
-    public function testToArrayWithGenerator(): void
-    {
-        $gen = (static function (): Generator {
-            yield 1;
-            yield 2;
-        })();
-        self::assertEquals([1, 2], TypeCaster::toArray($gen));
-    }
-
-    public function testToArrayWithNullReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toArray(null));
-    }
-
-    public function testToArrayWithIntReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toArray(42));
-    }
-
-    public function testToArrayWithStringReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toArray('hello'));
-    }
-
-    public function testToArrayWithObjectReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toArray($this->stdObj));
-    }
-
-    public function testToCypherListWithArray(): void
-    {
-        $result = TypeCaster::toCypherList([1, 2, 3]);
-        self::assertInstanceOf(CypherList::class, $result);
-        self::assertEquals([1, 2, 3], $result->toArray());
-    }
-
-    public function testToCypherListWithEmptyArray(): void
-    {
-        $result = TypeCaster::toCypherList([]);
-        self::assertInstanceOf(CypherList::class, $result);
-        self::assertEquals([], $result->toArray());
-    }
-
-    public function testToCypherListWithIterator(): void
-    {
-        $result = TypeCaster::toCypherList(new ArrayIterator([10, 20]));
-        self::assertInstanceOf(CypherList::class, $result);
-        self::assertEquals([10, 20], $result->toArray());
-    }
-
-    public function testToCypherListWithCypherList(): void
-    {
-        $list = new CypherList([1, 2]);
-        $result = TypeCaster::toCypherList($list);
-        self::assertInstanceOf(CypherList::class, $result);
-        self::assertEquals([1, 2], $result->toArray());
-    }
-
-    public function testToCypherListWithCypherMap(): void
-    {
-        $result = TypeCaster::toCypherList(new CypherMap(['x' => 1]));
-        self::assertInstanceOf(CypherList::class, $result);
-        self::assertEquals([1], $result->toArray());
-    }
-
-    public function testToCypherListWithNullReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toCypherList(null));
-    }
-
-    public function testToCypherListWithIntReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toCypherList(42));
-    }
-
-    public function testToCypherListWithStringReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toCypherList('hello'));
-    }
-
-    public function testToCypherListWithObjectReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toCypherList($this->stdObj));
-    }
-
-    public function testToCypherMapWithArray(): void
-    {
-        $result = TypeCaster::toCypherMap(['a' => 1, 'b' => 2]);
-        self::assertInstanceOf(CypherMap::class, $result);
-        self::assertEquals(['a' => 1, 'b' => 2], $result->toArray());
-    }
-
-    public function testToCypherMapWithEmptyArray(): void
-    {
-        $result = TypeCaster::toCypherMap([]);
-        self::assertInstanceOf(CypherMap::class, $result);
-        self::assertEquals([], $result->toArray());
-    }
-
-    public function testToCypherMapWithIterator(): void
-    {
-        $result = TypeCaster::toCypherMap(new ArrayIterator(['x' => 10, 'y' => 20]));
-        self::assertInstanceOf(CypherMap::class, $result);
-        self::assertEquals(['x' => 10, 'y' => 20], $result->toArray());
-    }
-
-    public function testToCypherMapWithCypherMap(): void
-    {
-        $map = new CypherMap(['k' => 'v']);
-        $result = TypeCaster::toCypherMap($map);
-        self::assertInstanceOf(CypherMap::class, $result);
-        self::assertEquals(['k' => 'v'], $result->toArray());
-    }
-
-    public function testToCypherMapWithCypherList(): void
-    {
-        $result = TypeCaster::toCypherMap(new CypherList([1, 2]));
-        self::assertInstanceOf(CypherMap::class, $result);
-        self::assertEquals(['0' => 1, '1' => 2], $result->toArray());
-    }
-
-    public function testToCypherMapWithNullReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toCypherMap(null));
-    }
-
-    public function testToCypherMapWithIntReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toCypherMap(42));
-    }
-
-    public function testToCypherMapWithStringReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toCypherMap('hello'));
-    }
-
-    public function testToCypherMapWithObjectReturnsNull(): void
-    {
-        self::assertNull(TypeCaster::toCypherMap($this->stdObj));
+        $stdObj = new stdClass();
+        $this->expectException(InvalidTypeCast::class);
+        $this->expectExceptionMessage('Cannot cast stdClass to Stringable');
+        TypeCaster::toClass($stdObj, Stringable::class);
     }
 }

--- a/tests/Unit/TypeCasterTest.php
+++ b/tests/Unit/TypeCasterTest.php
@@ -1,0 +1,451 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Tests\Unit;
+
+use ArrayIterator;
+use Generator;
+use Laudis\Neo4j\TypeCaster;
+use Laudis\Neo4j\Types\CypherList;
+use Laudis\Neo4j\Types\CypherMap;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Stringable;
+
+final class TypeCasterTest extends TestCase
+{
+    private stdClass $stdObj;
+
+    private object $stringable;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->stdObj = new stdClass();
+        $this->stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'stringable-value';
+            }
+        };
+    }
+
+    public function testToStringWithNull(): void
+    {
+        self::assertSame('', TypeCaster::toString(null));
+    }
+
+    public function testToStringWithInt(): void
+    {
+        self::assertSame('42', TypeCaster::toString(42));
+    }
+
+    public function testToStringWithFloat(): void
+    {
+        self::assertSame('3.14', TypeCaster::toString(3.14));
+    }
+
+    public function testToStringWithBoolTrue(): void
+    {
+        self::assertSame('1', TypeCaster::toString(true));
+    }
+
+    public function testToStringWithBoolFalse(): void
+    {
+        self::assertSame('', TypeCaster::toString(false));
+    }
+
+    public function testToStringWithString(): void
+    {
+        self::assertSame('hello', TypeCaster::toString('hello'));
+    }
+
+    public function testToStringWithStringEmpty(): void
+    {
+        self::assertSame('', TypeCaster::toString(''));
+    }
+
+    public function testToStringWithStringable(): void
+    {
+        self::assertSame('stringable-value', TypeCaster::toString($this->stringable));
+    }
+
+    public function testToStringWithArrayReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toString([1, 2, 3]));
+    }
+
+    public function testToStringWithObjectReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toString($this->stdObj));
+    }
+
+    public function testToNull(): void
+    {
+        self::assertNull(TypeCaster::toNull());
+    }
+
+    public function testToIntWithNull(): void
+    {
+        self::assertNull(TypeCaster::toInt(null));
+    }
+
+    public function testToIntWithInt(): void
+    {
+        self::assertSame(42, TypeCaster::toInt(42));
+    }
+
+    public function testToIntWithFloat(): void
+    {
+        self::assertSame(3, TypeCaster::toInt(3.14));
+    }
+
+    public function testToIntWithStringNumeric(): void
+    {
+        self::assertSame(123, TypeCaster::toInt('123'));
+    }
+
+    public function testToIntWithBoolTrue(): void
+    {
+        self::assertSame(1, TypeCaster::toInt(true));
+    }
+
+    public function testToIntWithBoolFalse(): void
+    {
+        self::assertSame(0, TypeCaster::toInt(false));
+    }
+
+    public function testToIntWithStringableNumeric(): void
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return '42';
+            }
+        };
+        self::assertSame(42, TypeCaster::toInt($stringable));
+    }
+
+    public function testToIntWithStringNonNumericReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toInt('abc'));
+    }
+
+    public function testToIntWithArrayReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toInt([1, 2, 3]));
+    }
+
+    public function testToFloatWithNull(): void
+    {
+        self::assertNull(TypeCaster::toFloat(null));
+    }
+
+    public function testToFloatWithInt(): void
+    {
+        self::assertSame(42.0, TypeCaster::toFloat(42));
+    }
+
+    public function testToFloatWithFloat(): void
+    {
+        self::assertSame(3.14, TypeCaster::toFloat(3.14));
+    }
+
+    public function testToFloatWithStringNumeric(): void
+    {
+        self::assertSame(99.9, TypeCaster::toFloat('99.9'));
+    }
+
+    public function testToFloatWithBoolTrue(): void
+    {
+        self::assertSame(1.0, TypeCaster::toFloat(true));
+    }
+
+    public function testToFloatWithBoolFalse(): void
+    {
+        self::assertSame(0.0, TypeCaster::toFloat(false));
+    }
+
+    public function testToFloatWithStringableNumeric(): void
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return '42.5';
+            }
+        };
+        self::assertSame(42.5, TypeCaster::toFloat($stringable));
+    }
+
+    public function testToFloatWithStringNonNumericReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toFloat('abc'));
+    }
+
+    public function testToFloatWithArrayReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toFloat([1, 2, 3]));
+    }
+
+    public function testToBoolWithNull(): void
+    {
+        self::assertNull(TypeCaster::toBool(null));
+    }
+
+    public function testToBoolWithTrue(): void
+    {
+        self::assertTrue(TypeCaster::toBool(true));
+    }
+
+    public function testToBoolWithFalse(): void
+    {
+        self::assertFalse(TypeCaster::toBool(false));
+    }
+
+    public function testToBoolWithIntOne(): void
+    {
+        self::assertTrue(TypeCaster::toBool(1));
+    }
+
+    public function testToBoolWithIntZero(): void
+    {
+        self::assertFalse(TypeCaster::toBool(0));
+    }
+
+    public function testToBoolWithStringOne(): void
+    {
+        self::assertTrue(TypeCaster::toBool('1'));
+    }
+
+    public function testToBoolWithStringZero(): void
+    {
+        self::assertFalse(TypeCaster::toBool('0'));
+    }
+
+    public function testToBoolWithStringNonNumericReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toBool('true'));
+    }
+
+    public function testToBoolWithArrayReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toBool([1, 2, 3]));
+    }
+
+    public function testToClassWithMatchingClass(): void
+    {
+        self::assertSame($this->stdObj, TypeCaster::toClass($this->stdObj, stdClass::class));
+    }
+
+    public function testToClassWithWrongClass(): void
+    {
+        self::assertNull(TypeCaster::toClass($this->stdObj, Stringable::class));
+    }
+
+    public function testToClassWithStringableInstance(): void
+    {
+        self::assertSame($this->stringable, TypeCaster::toClass($this->stringable, Stringable::class));
+    }
+
+    public function testToClassWithStringReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toClass('hello', stdClass::class));
+    }
+
+    public function testToClassWithIntReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toClass(42, stdClass::class));
+    }
+
+    public function testToClassWithNullReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toClass(null, stdClass::class));
+    }
+
+    public function testToClassWithArrayReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toClass([], stdClass::class));
+    }
+
+    public function testToArrayWithArray(): void
+    {
+        self::assertEquals([1, 2, 3], TypeCaster::toArray([1, 2, 3]));
+    }
+
+    public function testToArrayWithAssociativeArray(): void
+    {
+        self::assertEquals([1, 2], TypeCaster::toArray(['a' => 1, 'b' => 2]));
+    }
+
+    public function testToArrayWithEmptyArray(): void
+    {
+        self::assertEquals([], TypeCaster::toArray([]));
+    }
+
+    public function testToArrayWithIterator(): void
+    {
+        self::assertEquals([10, 20], TypeCaster::toArray(new ArrayIterator([10, 20])));
+    }
+
+    public function testToArrayWithCypherList(): void
+    {
+        self::assertEquals([1, 2, 3], TypeCaster::toArray(new CypherList([1, 2, 3])));
+    }
+
+    public function testToArrayWithCypherMap(): void
+    {
+        self::assertEquals([1, 2], TypeCaster::toArray(new CypherMap(['x' => 1, 'y' => 2])));
+    }
+
+    public function testToArrayWithGenerator(): void
+    {
+        $gen = (static function (): Generator {
+            yield 1;
+            yield 2;
+        })();
+        self::assertEquals([1, 2], TypeCaster::toArray($gen));
+    }
+
+    public function testToArrayWithNullReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toArray(null));
+    }
+
+    public function testToArrayWithIntReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toArray(42));
+    }
+
+    public function testToArrayWithStringReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toArray('hello'));
+    }
+
+    public function testToArrayWithObjectReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toArray($this->stdObj));
+    }
+
+    public function testToCypherListWithArray(): void
+    {
+        $result = TypeCaster::toCypherList([1, 2, 3]);
+        self::assertInstanceOf(CypherList::class, $result);
+        self::assertEquals([1, 2, 3], $result->toArray());
+    }
+
+    public function testToCypherListWithEmptyArray(): void
+    {
+        $result = TypeCaster::toCypherList([]);
+        self::assertInstanceOf(CypherList::class, $result);
+        self::assertEquals([], $result->toArray());
+    }
+
+    public function testToCypherListWithIterator(): void
+    {
+        $result = TypeCaster::toCypherList(new ArrayIterator([10, 20]));
+        self::assertInstanceOf(CypherList::class, $result);
+        self::assertEquals([10, 20], $result->toArray());
+    }
+
+    public function testToCypherListWithCypherList(): void
+    {
+        $list = new CypherList([1, 2]);
+        $result = TypeCaster::toCypherList($list);
+        self::assertInstanceOf(CypherList::class, $result);
+        self::assertEquals([1, 2], $result->toArray());
+    }
+
+    public function testToCypherListWithCypherMap(): void
+    {
+        $result = TypeCaster::toCypherList(new CypherMap(['x' => 1]));
+        self::assertInstanceOf(CypherList::class, $result);
+        self::assertEquals([1], $result->toArray());
+    }
+
+    public function testToCypherListWithNullReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toCypherList(null));
+    }
+
+    public function testToCypherListWithIntReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toCypherList(42));
+    }
+
+    public function testToCypherListWithStringReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toCypherList('hello'));
+    }
+
+    public function testToCypherListWithObjectReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toCypherList($this->stdObj));
+    }
+
+    public function testToCypherMapWithArray(): void
+    {
+        $result = TypeCaster::toCypherMap(['a' => 1, 'b' => 2]);
+        self::assertInstanceOf(CypherMap::class, $result);
+        self::assertEquals(['a' => 1, 'b' => 2], $result->toArray());
+    }
+
+    public function testToCypherMapWithEmptyArray(): void
+    {
+        $result = TypeCaster::toCypherMap([]);
+        self::assertInstanceOf(CypherMap::class, $result);
+        self::assertEquals([], $result->toArray());
+    }
+
+    public function testToCypherMapWithIterator(): void
+    {
+        $result = TypeCaster::toCypherMap(new ArrayIterator(['x' => 10, 'y' => 20]));
+        self::assertInstanceOf(CypherMap::class, $result);
+        self::assertEquals(['x' => 10, 'y' => 20], $result->toArray());
+    }
+
+    public function testToCypherMapWithCypherMap(): void
+    {
+        $map = new CypherMap(['k' => 'v']);
+        $result = TypeCaster::toCypherMap($map);
+        self::assertInstanceOf(CypherMap::class, $result);
+        self::assertEquals(['k' => 'v'], $result->toArray());
+    }
+
+    public function testToCypherMapWithCypherList(): void
+    {
+        $result = TypeCaster::toCypherMap(new CypherList([1, 2]));
+        self::assertInstanceOf(CypherMap::class, $result);
+        self::assertEquals(['0' => 1, '1' => 2], $result->toArray());
+    }
+
+    public function testToCypherMapWithNullReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toCypherMap(null));
+    }
+
+    public function testToCypherMapWithIntReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toCypherMap(42));
+    }
+
+    public function testToCypherMapWithStringReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toCypherMap('hello'));
+    }
+
+    public function testToCypherMapWithObjectReturnsNull(): void
+    {
+        self::assertNull(TypeCaster::toCypherMap($this->stdObj));
+    }
+}


### PR DESCRIPTION
Adds unit tests for the TypeCaster class. Replaces null returns with InvalidTypeCast exceptions for invalid casts and updates CypherList and CypherMap to use it. Extracts a private tryToString helper that returns null on failure to simplify control flow in toFloat, toInt, and toBool.