### PR TITLE
Implement TestKit result iteration stubs and SummarizedResult::list()

### DIFF
--- a/src/Bolt/BoltConnection.php
+++ b/src/Bolt/BoltConnection.php
@@ -337,9 +337,12 @@ class BoltConnection implements ConnectionInterface
             return $tbr;
         } catch (Throwable $e) {
             $this->restoreOriginalTimeout();
-            // If we've received some records before the disconnect, return them so first next() succeeds and second next() fails.
+            // If we've received some records before the disconnect, return them so first next() succeeds.
+            // Second next() must pull again and fail with a connection error (TestKit exit_after_record scripts).
+            // Do not append []: BoltResult treats trailing empty SUCCESS as stream completion, so the iterator
+            // would stop cleanly instead of surfacing the disconnect. A synthetic has_more:true means "not done".
             if (!empty($tbr)) {
-                $tbr[] = [];
+                $tbr[] = ['has_more' => true];
 
                 /** @var non-empty-list<list> */
                 return $tbr;

--- a/src/Bolt/BoltResult.php
+++ b/src/Bolt/BoltResult.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Bolt;
 
+use function array_key_exists;
 use function array_splice;
 
 use Bolt\error\BoltException;
@@ -23,10 +24,10 @@ use function count;
 use Generator;
 
 use function in_array;
+use function is_array;
 
 use Iterator;
 use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -153,40 +154,34 @@ final class BoltResult implements Iterator
             throw $e;
         }
         // Neo4jException and other Throwable propagate naturally - no invalidate needed for server errors
-
-        // Safety check: ensure pull response $meta is not empty (pull() is typed non-empty-list but we defend against empty)
-        /** @psalm-suppress TypeDoesNotContainType */
-        if (empty($meta)) {
-            throw new RuntimeException('Empty response from server');
-        }
+        // $meta is non-empty: {@see BoltConnection::pull()} is contractually non-empty-list<list>.
 
         /** @var list<list> $rows */
         $rows = array_splice($meta, 0, count($meta) - 1);
         $this->rows = $rows;
 
-        /** @var array{0: array} $meta */
-        // Check if we have a valid summary
-        /** @psalm-suppress RedundantConditionGivenDocblockType */
-        if (count($meta) > 0 && is_array($meta[0])) {
-            // If summary is empty array and we have no rows, it's a normal completion (no records)
-            if (empty($meta[0]) && empty($rows)) {
-                // Normal completion with no records - mark as complete
-                $this->meta = [];
-            } elseif (!empty($meta[0])) {
-                // Valid summary with data
-                if (!array_key_exists('has_more', $meta[0]) || $meta[0]['has_more'] === false) {
-                    $this->meta = $meta[0];
-                }
-            } elseif (!empty($rows)) {
-                // SUCCESS {} after records: Bolt may deserialize as []; stream is complete (not has_more)
-                if (!array_key_exists('has_more', $meta[0]) || $meta[0]['has_more'] === false) {
-                    $this->meta = $meta[0];
-                }
+        $summarySlot = $meta[0] ?? null;
+        if (!is_array($summarySlot)) {
+            // No summary received (connection closed before summary)
+            $this->meta = null;
+
+            return;
+        }
+
+        $summaryEmpty = $summarySlot === [];
+        $hasDataRows = $rows !== [];
+
+        if ($summaryEmpty && !$hasDataRows) {
+            // Normal completion with no records
+            $this->meta = [];
+        } elseif (!$summaryEmpty) {
+            // Valid summary map (e.g. has_more, counters, db, …)
+            if (!array_key_exists('has_more', $summarySlot) || $summarySlot['has_more'] === false) {
+                $this->meta = $summarySlot;
             }
         } else {
-            // No summary received (connection closed before summary)
-            // Set $this->meta to null so the next fetchResults() will try to pull again
-            $this->meta = null;
+            // Empty summary slot with data rows: Bolt SUCCESS {} after RECORDs — stream complete (no has_more keys).
+            $this->meta = $summarySlot;
         }
     }
 

--- a/src/Bolt/BoltResult.php
+++ b/src/Bolt/BoltResult.php
@@ -49,9 +49,35 @@ final class BoltResult implements Iterator
     ) {
     }
 
+    /**
+     * Remaining server pulls use PULL n=-1 (TestKit Optimization:ResultListFetchAll / list()).
+     */
+    private ?int $pullOverrideSize = null;
+
+    /**
+     * True after at least one {@see fetchResults()} (network pull). Used so list() can reset a stale
+     * cached generator before the first pull, but must not reset after next()+list() or rows replay.
+     */
+    private bool $networkPullOccurred = false;
+
+    public function prepareForResultListFetchAll(): void
+    {
+        $this->pullOverrideSize = -1;
+        // Drop cached generator only if no pull ran yet (e.g. valid()/getIt() touched before list()).
+        // If next() already ran, resetting would restart iterator() and duplicate records on list().
+        if ($this->it !== null && !$this->networkPullOccurred) {
+            $this->it = null;
+        }
+    }
+
     public function getFetchSize(): int
     {
         return $this->fetchSize;
+    }
+
+    private function effectivePullSize(): int
+    {
+        return $this->pullOverrideSize ?? $this->fetchSize;
     }
 
     private ?Generator $it = null;
@@ -116,8 +142,10 @@ final class BoltResult implements Iterator
 
     private function fetchResults(): void
     {
+        $this->networkPullOccurred = true;
+
         try {
-            $meta = $this->connection->pull($this->qid, $this->fetchSize);
+            $meta = $this->connection->pull($this->qid, $this->effectivePullSize());
         } catch (BoltConnectException|BoltException $e) {
             // Invalidate connection on socket/network errors so pool does not reuse it.
             // Rethrow as-is - Session retry logic inspects the actual exception via isConnectionError().
@@ -141,7 +169,6 @@ final class BoltResult implements Iterator
         /** @psalm-suppress RedundantConditionGivenDocblockType */
         if (count($meta) > 0 && is_array($meta[0])) {
             // If summary is empty array and we have no rows, it's a normal completion (no records)
-            // If summary is empty array but we have rows, it's a partial pull from disconnect
             if (empty($meta[0]) && empty($rows)) {
                 // Normal completion with no records - mark as complete
                 $this->meta = [];
@@ -150,12 +177,11 @@ final class BoltResult implements Iterator
                 if (!array_key_exists('has_more', $meta[0]) || $meta[0]['has_more'] === false) {
                     $this->meta = $meta[0];
                 }
-            } else {
-                // Empty summary but we have rows - partial result from disconnect
-                // Set $this->meta to null so the next fetchResults() will try to pull again
-                // This allows the first record to be consumed, and the next fetch will fail
-                // which is the expected behavior for tests like exit_after_record
-                $this->meta = null;
+            } elseif (!empty($rows)) {
+                // SUCCESS {} after records: Bolt may deserialize as []; stream is complete (not has_more)
+                if (!array_key_exists('has_more', $meta[0]) || $meta[0]['has_more'] === false) {
+                    $this->meta = $meta[0];
+                }
             }
         } else {
             // No summary received (connection closed before summary)

--- a/src/Databags/SummarizedResult.php
+++ b/src/Databags/SummarizedResult.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\Databags;
 
+use Closure;
 use Generator;
 use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
 use Laudis\Neo4j\Types\CypherList;
@@ -34,16 +35,33 @@ final class SummarizedResult extends CypherList
     private array $keys;
 
     /**
+     * Bolt: before materializing all records, use PULL n=-1 for remaining pulls (Result.list()).
+     *
+     * @var (Closure():void)|null
+     */
+    private readonly ?Closure $prepareListFetchAll;
+
+    /**
+     * Keeps the Bolt result stream alive until this summarized result is consumed (avoids premature BoltResult::__destruct).
+     *
+     * @var object|null
+     */
+    private readonly ?object $boltResultRef;
+
+    /**
      * @psalm-mutation-free
      *
      * @param iterable<mixed, CypherMap<OGMTypes>>|callable():Generator<mixed, CypherMap<OGMTypes>> $iterable
      * @param list<string>                                                                          $keys
+     * @param (Closure():void)|null                                                                 $prepareListFetchAll
      */
-    public function __construct(?ResultSummary &$summary, iterable|callable $iterable = [], array $keys = [])
+    public function __construct(?ResultSummary &$summary, iterable|callable $iterable = [], array $keys = [], ?Closure $prepareListFetchAll = null, ?object $boltResultRef = null)
     {
         parent::__construct($iterable);
         $this->summary = &$summary;
         $this->keys = $keys;
+        $this->prepareListFetchAll = $prepareListFetchAll;
+        $this->boltResultRef = $boltResultRef;
     }
 
     /**
@@ -84,5 +102,26 @@ final class SummarizedResult extends CypherList
     public function keys(): array
     {
         return $this->keys;
+    }
+
+    /**
+     * Materialize all remaining records (Bolt: remaining pulls use fetch-all / PULL n=-1 when configured).
+     *
+     * Does not rewind: if the caller already consumed rows with next(), only unconsumed rows are returned.
+     * (iterator_to_array() would call rewind() and duplicate those rows.)
+     *
+     * @return list<CypherMap<OGMTypes>>
+     */
+    public function list(): array
+    {
+        $this->prepareListFetchAll?->__invoke();
+
+        $rows = [];
+        while ($this->valid()) {
+            $rows[] = $this->current();
+            $this->next();
+        }
+
+        return $rows;
     }
 }

--- a/src/Databags/SummarizedResult.php
+++ b/src/Databags/SummarizedResult.php
@@ -43,8 +43,6 @@ final class SummarizedResult extends CypherList
 
     /**
      * Keeps the Bolt result stream alive until this summarized result is consumed (avoids premature BoltResult::__destruct).
-     *
-     * @var object|null
      */
     private readonly ?object $boltResultRef;
 

--- a/src/Formatter/SummarizedResultFormatter.php
+++ b/src/Formatter/SummarizedResultFormatter.php
@@ -194,17 +194,29 @@ final class SummarizedResultFormatter
                 );
             });
 
-        $formattedResult = $this->processBoltResult($meta, $result, $connection, $holder);
+        $boltResult = $result;
+        $formattedResult = $this->processBoltResult($meta, $boltResult, $connection, $holder);
 
-        /** @var SummarizedResult */
-        $result = (new CypherList($formattedResult))->withCacheLimit($result->getFetchSize());
+        $recordsList = (new CypherList($formattedResult))->withCacheLimit($this->clientSideCacheLimitFromBoltFetchSize($boltResult->getFetchSize()));
         // Safely get fields from metadata, defaulting to empty array if missing (indicates connection loss)
         $keys = [];
         if (array_key_exists('fields', $meta)) {
             $keys = $meta['fields'];
         }
 
-        return new SummarizedResult($summary, $result, $keys);
+        $prepareListFetchAll = static function () use ($boltResult): void {
+            $boltResult->prepareForResultListFetchAll();
+        };
+
+        return new SummarizedResult($summary, $recordsList, $keys, $prepareListFetchAll, $boltResult);
+    }
+
+    /**
+     * Bolt fetch size -1 means one PULL with n=-1; client-side CypherList cache must stay non-negative.
+     */
+    private function clientSideCacheLimitFromBoltFetchSize(int $boltFetchSize): int
+    {
+        return $boltFetchSize < 0 ? PHP_INT_MAX : $boltFetchSize;
     }
 
     public function formatArgs(array $profiledPlanData): PlanArguments
@@ -277,7 +289,7 @@ final class SummarizedResultFormatter
             foreach ($result as $row) {
                 yield $this->formatRow($meta, $row);
             }
-        }))->withCacheLimit($result->getFetchSize());
+        }))->withCacheLimit($this->clientSideCacheLimitFromBoltFetchSize($result->getFetchSize()));
 
         $connection->subscribeResult($tbr);
         $result->addFinishedCallback(function (array $response) use ($holder) {

--- a/testkit-backend/src/Handlers/ResultList.php
+++ b/testkit-backend/src/Handlers/ResultList.php
@@ -15,63 +15,57 @@ namespace Laudis\Neo4j\TestkitBackend\Handlers;
 
 use Bolt\error\BoltException;
 use Laudis\Neo4j\Databags\Neo4jError;
+use Laudis\Neo4j\Databags\SummarizedResult;
 use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\TestkitBackend\Contracts\RequestHandlerInterface;
 use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
 use Laudis\Neo4j\TestkitBackend\MainRepository;
-use Laudis\Neo4j\TestkitBackend\Requests\ResultNextRequest;
+use Laudis\Neo4j\TestkitBackend\Requests\ResultListRequest;
 use Laudis\Neo4j\TestkitBackend\Responses\DriverErrorResponse;
-use Laudis\Neo4j\TestkitBackend\Responses\NullRecordResponse;
-use Laudis\Neo4j\TestkitBackend\Responses\RecordResponse;
-use Laudis\Neo4j\TestkitBackend\Responses\Types\CypherObject;
+use Laudis\Neo4j\TestkitBackend\Responses\RecordListResponse;
 use Throwable;
 
 /**
- * @implements RequestHandlerInterface<ResultNextRequest>
+ * Materializes the full result (PULL / iterate) for TestKit Result.list().
+ *
+ * @implements RequestHandlerInterface<ResultListRequest>
  */
-final class ResultNext implements RequestHandlerInterface
+final class ResultList implements RequestHandlerInterface
 {
-    private MainRepository $repository;
-
-    public function __construct(MainRepository $repository)
-    {
-        $this->repository = $repository;
+    public function __construct(
+        private readonly MainRepository $repository,
+    ) {
     }
 
     /**
-     * @param ResultNextRequest $request
+     * @param ResultListRequest $request
      */
     public function handle($request): TestkitResponseInterface
     {
         try {
-            $record = $this->repository->getRecords($request->getResultId());
-            if ($record instanceof TestkitResponseInterface) {
-                return $record;
+            $result = $this->repository->getRecords($request->getResultId());
+            if ($result instanceof TestkitResponseInterface) {
+                return $result;
             }
 
-            $iterator = $this->repository->getIterator($request->getResultId());
-            // Defer Iterator::next() until here so the Bolt stream is not advanced (e.g. second PULL)
-            // until the client asks for the next record — required for disconnect stubs and Result.list().
-            $this->repository->drainPendingIteratorNexts($request->getResultId(), $iterator);
-
-            // Check if iterator is valid - this may trigger generator to start and fetch results
-            // If the connection is closed, this will throw an exception which we catch below
-            if (!$iterator->valid()) {
-                return new NullRecordResponse();
+            $rows = [];
+            if ($result instanceof SummarizedResult) {
+                $this->repository->drainPendingIteratorNexts($request->getResultId(), $result);
+                $iterable = $result->list();
+            } else {
+                $iterable = $result;
+            }
+            foreach ($iterable as $row) {
+                $r = [];
+                foreach ($row as $value) {
+                    $r[] = $value;
+                }
+                $rows[] = $r;
             }
 
-            // Get the current record
-            $current = $iterator->current();
-            $this->repository->setIteratorFetchedFirst($request->getResultId(), true);
+            $this->repository->removeRecords($request->getResultId());
 
-            $values = [];
-            foreach ($current as $value) {
-                $values[] = CypherObject::autoDetect($value);
-            }
-
-            $this->repository->addPendingIteratorNext($request->getResultId());
-
-            return new RecordResponse($values);
+            return new RecordListResponse($rows);
         } catch (Neo4jException $e) {
             $this->repository->removeRecords($request->getResultId());
 

--- a/testkit-backend/src/Handlers/ResultPeek.php
+++ b/testkit-backend/src/Handlers/ResultPeek.php
@@ -19,7 +19,7 @@ use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\TestkitBackend\Contracts\RequestHandlerInterface;
 use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
 use Laudis\Neo4j\TestkitBackend\MainRepository;
-use Laudis\Neo4j\TestkitBackend\Requests\ResultNextRequest;
+use Laudis\Neo4j\TestkitBackend\Requests\ResultPeekRequest;
 use Laudis\Neo4j\TestkitBackend\Responses\DriverErrorResponse;
 use Laudis\Neo4j\TestkitBackend\Responses\NullRecordResponse;
 use Laudis\Neo4j\TestkitBackend\Responses\RecordResponse;
@@ -27,19 +27,19 @@ use Laudis\Neo4j\TestkitBackend\Responses\Types\CypherObject;
 use Throwable;
 
 /**
- * @implements RequestHandlerInterface<ResultNextRequest>
+ * Peek at the next record without advancing the iterator position used by ResultNext.
+ *
+ * @implements RequestHandlerInterface<ResultPeekRequest>
  */
-final class ResultNext implements RequestHandlerInterface
+final class ResultPeek implements RequestHandlerInterface
 {
-    private MainRepository $repository;
-
-    public function __construct(MainRepository $repository)
-    {
-        $this->repository = $repository;
+    public function __construct(
+        private readonly MainRepository $repository,
+    ) {
     }
 
     /**
-     * @param ResultNextRequest $request
+     * @param ResultPeekRequest $request
      */
     public function handle($request): TestkitResponseInterface
     {
@@ -50,26 +50,17 @@ final class ResultNext implements RequestHandlerInterface
             }
 
             $iterator = $this->repository->getIterator($request->getResultId());
-            // Defer Iterator::next() until here so the Bolt stream is not advanced (e.g. second PULL)
-            // until the client asks for the next record — required for disconnect stubs and Result.list().
-            $this->repository->drainPendingIteratorNexts($request->getResultId(), $iterator);
 
-            // Check if iterator is valid - this may trigger generator to start and fetch results
-            // If the connection is closed, this will throw an exception which we catch below
             if (!$iterator->valid()) {
                 return new NullRecordResponse();
             }
 
-            // Get the current record
             $current = $iterator->current();
-            $this->repository->setIteratorFetchedFirst($request->getResultId(), true);
 
             $values = [];
             foreach ($current as $value) {
                 $values[] = CypherObject::autoDetect($value);
             }
-
-            $this->repository->addPendingIteratorNext($request->getResultId());
 
             return new RecordResponse($values);
         } catch (Neo4jException $e) {

--- a/testkit-backend/src/Handlers/ResultPeek.php
+++ b/testkit-backend/src/Handlers/ResultPeek.php
@@ -27,7 +27,8 @@ use Laudis\Neo4j\TestkitBackend\Responses\Types\CypherObject;
 use Throwable;
 
 /**
- * Peek at the next record without advancing the iterator position used by ResultNext.
+ * Peek at the next record without consuming it (no {@see Iterator::next()} after the peek itself).
+ * Deferred advances from prior {@see ResultNext} must be applied first so peek sees the correct row.
  *
  * @implements RequestHandlerInterface<ResultPeekRequest>
  */
@@ -50,6 +51,7 @@ final class ResultPeek implements RequestHandlerInterface
             }
 
             $iterator = $this->repository->getIterator($request->getResultId());
+            $this->repository->drainPendingIteratorNexts($request->getResultId(), $iterator);
 
             if (!$iterator->valid()) {
                 return new NullRecordResponse();

--- a/testkit-backend/src/Handlers/ResultSingle.php
+++ b/testkit-backend/src/Handlers/ResultSingle.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\TestkitBackend\Handlers;
 
+use Laudis\Neo4j\Databags\Neo4jError;
+use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\TestkitBackend\Contracts\RequestHandlerInterface;
 use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
 use Laudis\Neo4j\TestkitBackend\MainRepository;
 use Laudis\Neo4j\TestkitBackend\Requests\ResultSingleRequest;
-use Laudis\Neo4j\TestkitBackend\Responses\BackendErrorResponse;
+use Laudis\Neo4j\TestkitBackend\Responses\DriverErrorResponse;
 use Laudis\Neo4j\TestkitBackend\Responses\RecordResponse;
+use Laudis\Neo4j\TestkitBackend\Responses\Types\CypherObject;
 
 /**
  * Request to expect and return exactly one record in the result stream.
@@ -32,7 +35,7 @@ use Laudis\Neo4j\TestkitBackend\Responses\RecordResponse;
  */
 final class ResultSingle implements RequestHandlerInterface
 {
-    private function __construct(
+    public function __construct(
         private readonly MainRepository $repository,
     ) {
     }
@@ -41,17 +44,24 @@ final class ResultSingle implements RequestHandlerInterface
     {
         $record = $this->repository->getRecords($request->getResultId());
         if ($record instanceof TestkitResponseInterface) {
-            return new BackendErrorResponse('Something went wrong with the result handling');
+            $err = new Neo4jException([Neo4jError::fromMessageAndCode('Neo.ClientError.Statement.ResultNotSingle', 'Something went wrong with the result handling')]);
+
+            return new DriverErrorResponse($request->getResultId(), $err);
         }
 
         $count = $record->count();
         if ($count !== 1) {
-            return new BackendErrorResponse(sprintf('Found exactly %s result rows, but expected just one.', $count));
+            $err = new Neo4jException([Neo4jError::fromMessageAndCode(
+                'Neo.ClientError.Statement.ResultNotSingle',
+                sprintf('Expected exactly one result row, found %d.', $count)
+            )]);
+
+            return new DriverErrorResponse($request->getResultId(), $err);
         }
 
         $values = [];
         foreach ($record->getAsCypherMap(0) as $value) {
-            $values[] = $value;
+            $values[] = CypherObject::autoDetect($value);
         }
 
         return new RecordResponse($values);

--- a/testkit-backend/src/Handlers/ResultSingleOptional.php
+++ b/testkit-backend/src/Handlers/ResultSingleOptional.php
@@ -19,59 +19,55 @@ use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\TestkitBackend\Contracts\RequestHandlerInterface;
 use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
 use Laudis\Neo4j\TestkitBackend\MainRepository;
-use Laudis\Neo4j\TestkitBackend\Requests\ResultNextRequest;
+use Laudis\Neo4j\TestkitBackend\Requests\ResultSingleOptionalRequest;
 use Laudis\Neo4j\TestkitBackend\Responses\DriverErrorResponse;
-use Laudis\Neo4j\TestkitBackend\Responses\NullRecordResponse;
-use Laudis\Neo4j\TestkitBackend\Responses\RecordResponse;
-use Laudis\Neo4j\TestkitBackend\Responses\Types\CypherObject;
+use Laudis\Neo4j\TestkitBackend\Responses\RecordOptionalResponse;
 use Throwable;
 
 /**
- * @implements RequestHandlerInterface<ResultNextRequest>
+ * @implements RequestHandlerInterface<ResultSingleOptionalRequest>
  */
-final class ResultNext implements RequestHandlerInterface
+final class ResultSingleOptional implements RequestHandlerInterface
 {
-    private MainRepository $repository;
-
-    public function __construct(MainRepository $repository)
-    {
-        $this->repository = $repository;
+    public function __construct(
+        private readonly MainRepository $repository,
+    ) {
     }
 
     /**
-     * @param ResultNextRequest $request
+     * @param ResultSingleOptionalRequest $request
      */
     public function handle($request): TestkitResponseInterface
     {
         try {
-            $record = $this->repository->getRecords($request->getResultId());
-            if ($record instanceof TestkitResponseInterface) {
-                return $record;
+            $result = $this->repository->getRecords($request->getResultId());
+            if ($result instanceof TestkitResponseInterface) {
+                return $result;
             }
 
-            $iterator = $this->repository->getIterator($request->getResultId());
-            // Defer Iterator::next() until here so the Bolt stream is not advanced (e.g. second PULL)
-            // until the client asks for the next record — required for disconnect stubs and Result.list().
-            $this->repository->drainPendingIteratorNexts($request->getResultId(), $iterator);
-
-            // Check if iterator is valid - this may trigger generator to start and fetch results
-            // If the connection is closed, this will throw an exception which we catch below
-            if (!$iterator->valid()) {
-                return new NullRecordResponse();
+            $rows = [];
+            foreach ($result as $row) {
+                $r = [];
+                foreach ($row as $value) {
+                    $r[] = $value;
+                }
+                $rows[] = $r;
             }
 
-            // Get the current record
-            $current = $iterator->current();
-            $this->repository->setIteratorFetchedFirst($request->getResultId(), true);
+            $this->repository->removeRecords($request->getResultId());
 
-            $values = [];
-            foreach ($current as $value) {
-                $values[] = CypherObject::autoDetect($value);
+            $n = count($rows);
+            if ($n === 0) {
+                return new RecordOptionalResponse(null, []);
+            }
+            if ($n === 1) {
+                return new RecordOptionalResponse($rows[0], []);
             }
 
-            $this->repository->addPendingIteratorNext($request->getResultId());
-
-            return new RecordResponse($values);
+            return new RecordOptionalResponse(
+                $rows[0],
+                ['Expected a single record but found multiple records in the stream.']
+            );
         } catch (Neo4jException $e) {
             $this->repository->removeRecords($request->getResultId());
 

--- a/testkit-backend/src/MainRepository.php
+++ b/testkit-backend/src/MainRepository.php
@@ -43,6 +43,18 @@ final class MainRepository
     /** @var array<string, bool> */
     private array $iteratorFetchedFirst;
 
+    /** @var array<string, bool> After ResultPeek advanced the iterator, ResultNext must not advance again. */
+    private array $peekPrimed = [];
+
+    /**
+     * Count of {@see Iterator::next()} calls owed before the next read: one per record already returned
+     * to TestKit without advancing the shared iterator (advancing immediately would run the next Bolt pull
+     * too early — e.g. disconnect tests expect the second pull on the second {@see ResultNext}, not after the first).
+     *
+     * @var array<string, int>
+     */
+    private array $pendingIteratorNextCount = [];
+
     /**
      * @param array<string, DriverInterface<SummarizedResult<CypherMap<OGMTypes>>>>               $drivers
      * @param array<string, SessionInterface<SummarizedResult<CypherMap<OGMTypes>>>>              $sessions
@@ -94,6 +106,55 @@ final class MainRepository
     }
 
     /**
+     * ResultPeek advanced the iterator; the following ResultNext must skip its leading {@see Iterator::next()}.
+     */
+    public function setPeekPrimed(Uuid $id, bool $value): void
+    {
+        if ($value) {
+            $this->peekPrimed[$id->toRfc4122()] = true;
+        } else {
+            unset($this->peekPrimed[$id->toRfc4122()]);
+        }
+    }
+
+    public function consumePeekPrimed(Uuid $id): bool
+    {
+        $key = $id->toRfc4122();
+        if (!isset($this->peekPrimed[$key])) {
+            return false;
+        }
+        unset($this->peekPrimed[$key]);
+
+        return true;
+    }
+
+    /**
+     * After returning a record from {@see ResultNext}, the iterator must advance before the next read;
+     * defer that advance so the Bolt layer does not pull until the following ResultNext or Result.list().
+     */
+    public function addPendingIteratorNext(Uuid $id): void
+    {
+        $key = $id->toRfc4122();
+        $this->pendingIteratorNextCount[$key] = ($this->pendingIteratorNextCount[$key] ?? 0) + 1;
+    }
+
+    /**
+     * Applies deferred {@see Iterator::next()} calls (e.g. before the next ResultNext or before Result.list()).
+     */
+    public function drainPendingIteratorNexts(Uuid $id, Iterator $iterator): void
+    {
+        $key = $id->toRfc4122();
+        $n = $this->pendingIteratorNextCount[$key] ?? 0;
+        if ($n === 0) {
+            return;
+        }
+        unset($this->pendingIteratorNextCount[$key]);
+        for ($i = 0; $i < $n; ++$i) {
+            $iterator->next();
+        }
+    }
+
+    /**
      * @return DriverInterface<SummarizedResult<CypherMap<OGMTypes>>>
      */
     public function getDriver(Uuid $id): DriverInterface
@@ -136,7 +197,8 @@ final class MainRepository
 
     public function removeRecords(Uuid $id): void
     {
-        unset($this->records[$id->toRfc4122()]);
+        $key = $id->toRfc4122();
+        unset($this->records[$key], $this->iteratorFetchedFirst[$key], $this->peekPrimed[$key], $this->pendingIteratorNextCount[$key]);
     }
 
     /**

--- a/testkit-backend/src/MainRepository.php
+++ b/testkit-backend/src/MainRepository.php
@@ -120,7 +120,7 @@ final class MainRepository
     public function consumePeekPrimed(Uuid $id): bool
     {
         $key = $id->toRfc4122();
-        if (!isset($this->peekPrimed[$key])) {
+        if (!array_key_exists($key, $this->peekPrimed)) {
             return false;
         }
         unset($this->peekPrimed[$key]);

--- a/testkit-backend/src/RequestFactory.php
+++ b/testkit-backend/src/RequestFactory.php
@@ -27,7 +27,11 @@ use Laudis\Neo4j\TestkitBackend\Requests\NewDriverRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\NewSessionRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\ResolverResolutionCompletedRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\ResultConsumeRequest;
+use Laudis\Neo4j\TestkitBackend\Requests\ResultListRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\ResultNextRequest;
+use Laudis\Neo4j\TestkitBackend\Requests\ResultPeekRequest;
+use Laudis\Neo4j\TestkitBackend\Requests\ResultSingleOptionalRequest;
+use Laudis\Neo4j\TestkitBackend\Requests\ResultSingleRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\RetryableNegativeRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\RetryablePositiveRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\SessionBeginTransactionRequest;
@@ -68,6 +72,10 @@ final class RequestFactory
         'TransactionRollback' => TransactionRollbackRequest::class,
         'TransactionClose' => TransactionCloseRequest::class,
         'ResultNext' => ResultNextRequest::class,
+        'ResultSingle' => ResultSingleRequest::class,
+        'ResultList' => ResultListRequest::class,
+        'ResultPeek' => ResultPeekRequest::class,
+        'ResultSingleOptional' => ResultSingleOptionalRequest::class,
         'ResultConsume' => ResultConsumeRequest::class,
         'RetryablePositive' => RetryablePositiveRequest::class,
         'RetryableNegative' => RetryableNegativeRequest::class,

--- a/testkit-backend/src/Requests/ResultListRequest.php
+++ b/testkit-backend/src/Requests/ResultListRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\TestkitBackend\Requests;
+
+use Symfony\Component\Uid\Uuid;
+
+final class ResultListRequest
+{
+    public function __construct(
+        private readonly Uuid $resultId,
+    ) {
+    }
+
+    public function getResultId(): Uuid
+    {
+        return $this->resultId;
+    }
+}

--- a/testkit-backend/src/Requests/ResultPeekRequest.php
+++ b/testkit-backend/src/Requests/ResultPeekRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\TestkitBackend\Requests;
+
+use Symfony\Component\Uid\Uuid;
+
+final class ResultPeekRequest
+{
+    public function __construct(
+        private readonly Uuid $resultId,
+    ) {
+    }
+
+    public function getResultId(): Uuid
+    {
+        return $this->resultId;
+    }
+}

--- a/testkit-backend/src/Requests/ResultSingleOptionalRequest.php
+++ b/testkit-backend/src/Requests/ResultSingleOptionalRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\TestkitBackend\Requests;
+
+use Symfony\Component\Uid\Uuid;
+
+final class ResultSingleOptionalRequest
+{
+    public function __construct(
+        private readonly Uuid $resultId,
+    ) {
+    }
+
+    public function getResultId(): Uuid
+    {
+        return $this->resultId;
+    }
+}

--- a/testkit-backend/src/Responses/RecordListResponse.php
+++ b/testkit-backend/src/Responses/RecordListResponse.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\TestkitBackend\Responses;
+
+use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
+use Laudis\Neo4j\TestkitBackend\Responses\Types\CypherObject;
+
+/**
+ * Response to ResultList — full materialized record list.
+ *
+ * @psalm-import-type OGMTypes from \Laudis\Neo4j\Formatter\OGMFormatter
+ */
+final class RecordListResponse implements TestkitResponseInterface
+{
+    /**
+     * @param list<list<mixed>> $records Each row is a list of cell values (OGM types).
+     */
+    public function __construct(
+        private readonly array $records,
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        $encoded = [];
+        foreach ($this->records as $row) {
+            $values = [];
+            foreach ($row as $value) {
+                $values[] = CypherObject::autoDetect($value);
+            }
+            $encoded[] = ['values' => $values];
+        }
+
+        return [
+            'name' => 'RecordList',
+            'data' => [
+                'records' => $encoded,
+            ],
+        ];
+    }
+}

--- a/testkit-backend/src/Responses/RecordListResponse.php
+++ b/testkit-backend/src/Responses/RecordListResponse.php
@@ -24,7 +24,7 @@ use Laudis\Neo4j\TestkitBackend\Responses\Types\CypherObject;
 final class RecordListResponse implements TestkitResponseInterface
 {
     /**
-     * @param list<list<mixed>> $records Each row is a list of cell values (OGM types).
+     * @param list<list<mixed>> $records each row is a list of cell values (OGM types)
      */
     public function __construct(
         private readonly array $records,

--- a/testkit-backend/src/Responses/RecordOptionalResponse.php
+++ b/testkit-backend/src/Responses/RecordOptionalResponse.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\TestkitBackend\Responses;
+
+use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
+use Laudis\Neo4j\TestkitBackend\Responses\Types\CypherObject;
+
+/**
+ * Response to ResultSingleOptional.
+ */
+final class RecordOptionalResponse implements TestkitResponseInterface
+{
+    /**
+     * @param list<mixed>|null $recordValues First record as flat list of cell values, or null
+     * @param list<string>     $warnings
+     */
+    public function __construct(
+        private readonly ?array $recordValues,
+        private readonly array $warnings,
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        $record = null;
+        if ($this->recordValues !== null) {
+            $values = [];
+            foreach ($this->recordValues as $value) {
+                $values[] = CypherObject::autoDetect($value);
+            }
+            $record = ['values' => $values];
+        }
+
+        return [
+            'name' => 'RecordOptional',
+            'data' => [
+                'record' => $record,
+                'warnings' => $this->warnings,
+            ],
+        ];
+    }
+}

--- a/testkit-backend/src/Responses/RecordResponse.php
+++ b/testkit-backend/src/Responses/RecordResponse.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Laudis\Neo4j\TestkitBackend\Responses;
 
 use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
+use Laudis\Neo4j\TestkitBackend\Responses\Types\CypherObject;
 
 /**
  * Represents a record from a result.
@@ -35,10 +36,18 @@ final class RecordResponse implements TestkitResponseInterface
 
     public function jsonSerialize(): array
     {
+        $serializedValues = [];
+        foreach ($this->values as $v) {
+            if (!$v instanceof TestkitResponseInterface) {
+                $v = CypherObject::autoDetect($v);
+            }
+            $serializedValues[] = $v->jsonSerialize();
+        }
+
         return [
             'name' => 'Record',
             'data' => [
-                'values' => $this->values,
+                'values' => $serializedValues,
             ],
         ];
     }

--- a/testkit-backend/testkit.sh
+++ b/testkit-backend/testkit.sh
@@ -159,6 +159,33 @@ python3 -m unittest -v \
     tests.stub.disconnects.test_disconnects.TestDisconnects.test_disconnect_on_tx_begin \
     tests.stub.disconnects.test_disconnects.TestDisconnects.test_disconnect_session_on_tx_pull_after_record \
     tests.stub.disconnects.test_disconnects.TestDisconnects.test_fail_on_reset \
+\
+    tests.stub.iteration.test_result_list.TestResultList.test_result_list_with_0_records \
+    tests.stub.iteration.test_result_list.TestResultList.test_result_list_with_1_records \
+    tests.stub.iteration.test_result_list.TestResultList.test_result_list_with_2_records \
+    tests.stub.iteration.test_result_list.TestResultList.test_session_run_result_list_pulls_all_records_at_once \
+    tests.stub.iteration.test_result_list.TestResultList.test_session_run_result_list_pulls_all_records_at_once_next_before_list \
+\
+    tests.stub.iteration.test_result_single.TestResultSingle.test_result_single_with_0_records \
+    tests.stub.iteration.test_result_single.TestResultSingle.test_result_single_with_1_records \
+    tests.stub.iteration.test_result_single.TestResultSingle.test_result_single_with_2_records \
+\
+    tests.stub.iteration.test_result_optional_single.TestResultSingleOptional.test_result_single_optional_with_0_records \
+    tests.stub.iteration.test_result_optional_single.TestResultSingleOptional.test_result_single_optional_with_1_records \
+    tests.stub.iteration.test_result_optional_single.TestResultSingleOptional.test_result_single_optional_with_2_records \
+\
+    tests.stub.iteration.test_result_peek.TestResultPeek.test_result_peek_with_0_records \
+    tests.stub.iteration.test_result_peek.TestResultPeek.test_result_peek_with_1_records \
+    tests.stub.iteration.test_result_peek.TestResultPeek.test_result_peek_with_2_records \
+\
+    tests.stub.iteration.test_iteration_session_run.TestIterationSessionRun.test_full_batch \
+    tests.stub.iteration.test_iteration_session_run.TestIterationSessionRun.test_half_batch \
+    tests.stub.iteration.test_iteration_session_run.TestIterationSessionRun.test_empty_batch \
+    tests.stub.iteration.test_iteration_session_run.TestIterationSessionRun.test_all \
+\
+   tests.stub.iteration.test_iteration_tx_run.TestIterationTxRun.test_batch \
+   tests.stub.iteration.test_iteration_tx_run.TestIterationTxRun.test_all \
+   tests.stub.iteration.test_iteration_tx_run.TestIterationTxRun.test_nested \
 
 EXIT_CODE=$?
 

--- a/tests/Unit/SummarizedResultListTest.php
+++ b/tests/Unit/SummarizedResultListTest.php
@@ -14,12 +14,15 @@ declare(strict_types=1);
 namespace Laudis\Neo4j\Tests\Unit;
 
 use Laudis\Neo4j\Databags\SummarizedResult;
+use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
 use Laudis\Neo4j\Types\CypherList;
 use Laudis\Neo4j\Types\CypherMap;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Mirrors TestKit stub: next() then list() must return only remaining rows (no rewind / duplicate).
+ *
+ * @psalm-import-type OGMTypes from SummarizedResultFormatter
  */
 final class SummarizedResultListTest extends TestCase
 {
@@ -32,15 +35,26 @@ final class SummarizedResultListTest extends TestCase
             }
         }))->withCacheLimit(2);
 
+        /** @var CypherList<CypherMap<OGMTypes>> $recordsList */
         $recordsList = (new CypherList($inner))->withCacheLimit(2);
         $result = new SummarizedResult($summary, $recordsList, ['n'], null, null);
 
         self::assertTrue($result->valid());
-        self::assertSame(1, $result->current()->get('n'));
+        $first = $result->current()->get('n');
+        self::assertIsInt($first);
+        self::assertSame(1, $first);
         $result->next();
 
         $rows = $result->list();
         self::assertCount(4, $rows);
-        self::assertSame([2, 3, 4, 5], array_map(static fn (CypherMap $m): int => $m->get('n'), $rows));
+
+        $nValues = [];
+        foreach ($rows as $row) {
+            self::assertInstanceOf(CypherMap::class, $row);
+            $n = $row->get('n');
+            self::assertIsInt($n);
+            $nValues[] = $n;
+        }
+        self::assertSame([2, 3, 4, 5], $nValues);
     }
 }

--- a/tests/Unit/SummarizedResultListTest.php
+++ b/tests/Unit/SummarizedResultListTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Tests\Unit;
+
+use Laudis\Neo4j\Databags\SummarizedResult;
+use Laudis\Neo4j\Types\CypherList;
+use Laudis\Neo4j\Types\CypherMap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Mirrors TestKit stub: next() then list() must return only remaining rows (no rewind / duplicate).
+ */
+final class SummarizedResultListTest extends TestCase
+{
+    public function testListAfterNextOmitsConsumedRow(): void
+    {
+        $summary = null;
+        $inner = (new CypherList(function (): iterable {
+            for ($i = 1; $i <= 5; ++$i) {
+                yield new CypherMap(['n' => $i]);
+            }
+        }))->withCacheLimit(2);
+
+        $recordsList = (new CypherList($inner))->withCacheLimit(2);
+        $result = new SummarizedResult($summary, $recordsList, ['n'], null, null);
+
+        self::assertTrue($result->valid());
+        self::assertSame(1, $result->current()->get('n'));
+        $result->next();
+
+        $rows = $result->list();
+        self::assertCount(4, $rows);
+        self::assertSame([2, 3, 4, 5], array_map(static fn (CypherMap $m): int => $m->get('n'), $rows));
+    }
+}


### PR DESCRIPTION
- Bolt / results: SummarizedResult::list() (remaining rows only), optional PULL n=-1 for fetch-all, safer disconnect handling (has_more sentinel), clearer SUCCESS/summary handling in BoltResult, keep BoltResult alive until consumed.

- TestKit backend: Handlers for list / peek / single / singleOptional, deferred next() so pulls match stubs, peek drains pending advances, wiring + responses, testkit.sh iteration tests.

- Tests: Unit test for next() + list() behavior.