### PR TITLE
Fix Aura routing and DatabaseNotFound on managed transactions.

### DIFF
--- a/auth.composer.github.example.json
+++ b/auth.composer.github.example.json
@@ -1,0 +1,5 @@
+{
+    "github-oauth": {
+        "github.com": "YOUR_GITHUB_PAT_WITH_repo_SCOPE"
+    }
+}

--- a/composer.laravel-private.example.json
+++ b/composer.laravel-private.example.json
@@ -1,0 +1,14 @@
+{
+    "_comment": "Merge into your Laravel app composer.json (private nagels-tech repo + Aura fix branch)",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:nagels-tech/neo4j-php-client.git"
+        }
+    ],
+    "require": {
+        "laudis/neo4j-php-client": "dev-fix/aura-database-routing as 3.4.4"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/scripts/push-aura-fix-branch.sh
+++ b/scripts/push-aura-fix-branch.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Push fix/aura-database-routing to the private remote (run from repo root).
+set -euo pipefail
+
+REMOTE="${1:-nagels}"
+BRANCH="fix/aura-database-routing"
+
+echo "Remote: ${REMOTE}"
+echo "Branch: ${BRANCH}"
+git status -sb
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo ""
+    echo "You have uncommitted changes. Commit first, for example:"
+    echo "  git add src/Neo4j/HomeDatabaseCache.php src/Neo4j/Neo4jConnectionPool.php src/Bolt/Session.php src/Databags/SessionConfiguration.php"
+    echo "  git commit -m \"Fix Aura routing and DatabaseNotFound on writeTransaction\""
+    exit 1
+fi
+
+git push -u "${REMOTE}" "${BRANCH}"
+echo ""
+echo "Done. In Laravel composer.json use:"
+echo "  \"laudis/neo4j-php-client\": \"dev-fix/aura-database-routing as 3.4.4\""

--- a/src/Basic/Session.php
+++ b/src/Basic/Session.php
@@ -55,6 +55,16 @@ final class Session implements SessionInterface
         return new UnmanagedTransaction($this->session->beginTransaction($statements, $config));
     }
 
+    public function beginWriteTransaction(?iterable $statements = null, ?TransactionConfiguration $config = null): UnmanagedTransaction
+    {
+        return new UnmanagedTransaction($this->session->beginWriteTransaction($statements, $config));
+    }
+
+    public function beginReadTransaction(?iterable $statements = null, ?TransactionConfiguration $config = null): UnmanagedTransaction
+    {
+        return new UnmanagedTransaction($this->session->beginReadTransaction($statements, $config));
+    }
+
     public function writeTransaction(callable $tsxHandler, ?TransactionConfiguration $config = null)
     {
         return $this->session->writeTransaction($tsxHandler, $config);

--- a/src/Bolt/BoltDriver.php
+++ b/src/Bolt/BoltDriver.php
@@ -80,15 +80,18 @@ final class BoltDriver implements DriverInterface
         if ($config !== null) {
             $sessionConfig = $sessionConfig->merge($config);
         }
-
         return new Session($sessionConfig, $this->pool, $this->formatter);
     }
 
     public function verifyConnectivity(?SessionConfiguration $config = null): bool
     {
         $config ??= SessionConfiguration::default();
+        $sessionConfig = SessionConfiguration::fromUri($this->parsedUrl, $this->pool->getLogger());
+        $config = $config->merge($sessionConfig);
+
         try {
-            GeneratorHelper::getReturnFromGenerator($this->pool->acquire($config));
+            $connection = GeneratorHelper::getReturnFromGenerator($this->pool->acquire($config));
+            $this->pool->release($connection);
         } catch (ConnectException $e) {
             $this->pool->getLogger()?->log(LogLevel::WARNING, 'Could not connect to server on URI '.$this->parsedUrl->__toString(), ['error' => $e]);
 

--- a/src/Bolt/Session.php
+++ b/src/Bolt/Session.php
@@ -48,6 +48,8 @@ final class Session implements SessionInterface
     private array $usedConnections = [];
     /** @psalm-readonly */
     private readonly BookmarkHolder $bookmarkHolder;
+    private ?SessionConfiguration $databaseFallbackConfig = null;
+    private int $databaseNotFoundRecoveryAttempts = 0;
 
     /**
      * @param ConnectionPool|Neo4jConnectionPool $pool
@@ -106,6 +108,7 @@ final class Session implements SessionInterface
     {
         $this->getLogger()?->log(LogLevel::INFO, 'Beginning write transaction', ['config' => $config]);
         $config = $this->mergeTsxConfig($config);
+        $this->resetDatabaseRecoveryState();
 
         return $this->retry($tsxHandler, false, $config);
     }
@@ -114,6 +117,7 @@ final class Session implements SessionInterface
     {
         $this->getLogger()?->log(LogLevel::INFO, 'Beginning read transaction', ['config' => $config]);
         $config = $this->mergeTsxConfig($config);
+        $this->resetDatabaseRecoveryState();
 
         return $this->retry($tsxHandler, true, $config);
     }
@@ -130,11 +134,8 @@ final class Session implements SessionInterface
         while (true) {
             $transaction = null;
             try {
-                if ($read) {
-                    $transaction = $this->startTransaction($config, $this->config->withAccessMode(AccessMode::READ()));
-                } else {
-                    $transaction = $this->startTransaction($config, $this->config->withAccessMode(AccessMode::WRITE()));
-                }
+                $accessMode = $this->resolveRoutingAccessMode($read);
+                $transaction = $this->startTransaction($config, $this->getSessionConfiguration()->withAccessMode($accessMode));
                 $tbr = $tsxHandler($transaction);
                 self::triggerLazyResult($tbr);
                 $transaction->commit();
@@ -178,6 +179,10 @@ final class Session implements SessionInterface
      */
     private function shouldRetryManagedTransaction(Neo4jException $e): bool
     {
+        if ($this->isDatabaseNotFound($e) && $this->tryRecoverFromDatabaseNotFound()) {
+            return true;
+        }
+
         if ($e->getTitle() === 'NotALeader' || $e->getNeo4jCode() === 'Neo.ClientError.Cluster.NotALeader') {
             return true;
         }
@@ -195,9 +200,14 @@ final class Session implements SessionInterface
      */
     private function handleConnectionFailure(): void
     {
+        $this->usedConnections = [];
+
         if ($this->pool instanceof Neo4jConnectionPool) {
-            $this->pool->clearRoutingTable($this->config);
+            $this->pool->invalidateRoutingForHost();
+
+            return;
         }
+
         $this->pool->close();
     }
 
@@ -239,6 +249,58 @@ final class Session implements SessionInterface
             || $title === 'NotALeader';
     }
 
+    private function getSessionConfiguration(): SessionConfiguration
+    {
+        return $this->databaseFallbackConfig ?? $this->config;
+    }
+
+    private function resetDatabaseRecoveryState(): void
+    {
+        $this->databaseNotFoundRecoveryAttempts = 0;
+        $this->databaseFallbackConfig = null;
+    }
+
+    private function isDatabaseNotFound(Neo4jException $e): bool
+    {
+        return $e->getNeo4jCode() === 'Neo.ClientError.Database.DatabaseNotFound'
+            || $e->getTitle() === 'DatabaseNotFound';
+    }
+
+    /**
+     * Clears routing state and drops an explicit database selection so Aura can resolve the home DB.
+     */
+    private function tryRecoverFromDatabaseNotFound(int $maxAttempts = 2): bool
+    {
+        if ($this->databaseNotFoundRecoveryAttempts >= $maxAttempts) {
+            return false;
+        }
+
+        ++$this->databaseNotFoundRecoveryAttempts;
+
+        $this->usedConnections = [];
+
+        if ($this->pool instanceof Neo4jConnectionPool) {
+            $this->pool->invalidateRoutingForHost();
+        }
+
+        if ($this->databaseFallbackConfig !== null) {
+            return true;
+        }
+
+        if ($this->config->getDatabase() === null) {
+            return true;
+        }
+
+        $fallback = $this->config->withDatabase(null);
+        if ($this->pool instanceof Neo4jConnectionPool) {
+            $fallback = $fallback->withAuraNormalizedDatabase($this->pool->getHost());
+        }
+
+        $this->databaseFallbackConfig = $fallback;
+
+        return true;
+    }
+
     /**
      * Execute a statement with automatic retry on connection errors.
      * Retries up to 3 times on connection failures, clearing routing table between attempts.
@@ -271,13 +333,17 @@ final class Session implements SessionInterface
      */
     private function executeStatementWithRetry(Statement $statement, TransactionConfiguration $config): SummarizedResult
     {    // Retry instant transactions up to 3 times on connection/routing errors; catch distinguishes retryable errors from client errors (syntax, auth) and clears routing table for cluster failover.
+        $this->resetDatabaseRecoveryState();
         $maxRetries = 3;
         $retries = 0;
 
         while ($retries < $maxRetries) {
             try {
-                return $this->beginInstantTransaction($this->config, $config)->runStatement($statement);
+                return $this->runStatementOnce($statement, $config);
             } catch (Neo4jException $e) {
+                if ($this->isDatabaseNotFound($e) && $this->tryRecoverFromDatabaseNotFound()) {
+                    continue;
+                }
                 if (!$this->shouldClearRoutingTable($e)) {
                     throw $e;
                 }
@@ -291,6 +357,38 @@ final class Session implements SessionInterface
         }
 
         throw new Neo4jException([Neo4jError::fromMessageAndCode('Neo.ClientError.General', 'Statement execution failed after maximum retries')]);
+    }
+
+    /**
+     * Routed clusters (neo4j://) need an explicit transaction for session.run(); autocommit RUN
+     * alone does not resolve the home database correctly on Aura.
+     */
+    private function runStatementOnce(Statement $statement, TransactionConfiguration $config): SummarizedResult
+    {
+        $sessionConfig = $this->getSessionConfiguration();
+
+        if ($this->pool instanceof Neo4jConnectionPool) {
+            if ($sessionConfig->getAccessMode() === null) {
+                $sessionConfig = $sessionConfig->withAccessMode(AccessMode::WRITE());
+            }
+
+            $transaction = $this->startTransaction($config, $sessionConfig);
+            try {
+                $result = $transaction->runStatement($statement);
+                self::triggerLazyResult($result);
+                $transaction->commit();
+
+                return $result;
+            } catch (Throwable $e) {
+                if (!$transaction->isFinished()) {
+                    $transaction->rollback();
+                }
+
+                throw $e;
+            }
+        }
+
+        return $this->beginInstantTransaction($sessionConfig, $config)->runStatement($statement);
     }
 
     /**
@@ -329,10 +427,41 @@ final class Session implements SessionInterface
      */
     public function beginTransaction(?iterable $statements = null, ?TransactionConfiguration $config = null): UnmanagedTransactionInterface
     {
-        $this->getLogger()?->log(LogLevel::INFO, 'Beginning transaction', ['statements' => $statements, 'config' => $config]);
-        $config = $this->mergeTsxConfig($config);
-        $tsx = $this->startTransaction($config, $this->config);
+        return $this->beginTransactionWithAccessMode($statements, $config, null);
+    }
 
+    public function beginWriteTransaction(?iterable $statements = null, ?TransactionConfiguration $config = null): UnmanagedTransactionInterface
+    {
+        return $this->beginTransactionWithAccessMode($statements, $config, AccessMode::WRITE());
+    }
+
+    public function beginReadTransaction(?iterable $statements = null, ?TransactionConfiguration $config = null): UnmanagedTransactionInterface
+    {
+        return $this->beginTransactionWithAccessMode($statements, $config, AccessMode::READ());
+    }
+
+    /**
+     * @param iterable<Statement>|null $statements
+     */
+    private function beginTransactionWithAccessMode(
+        ?iterable $statements,
+        ?TransactionConfiguration $config,
+        ?AccessMode $accessMode,
+    ): UnmanagedTransactionInterface {
+        $this->getLogger()?->log(LogLevel::INFO, 'Beginning transaction', [
+            'statements' => $statements,
+            'config' => $config,
+            'accessMode' => $accessMode?->getValue(),
+        ]);
+        $config = $this->mergeTsxConfig($config);
+        $sessionConfig = $this->getSessionConfiguration();
+        if ($accessMode !== null) {
+            $sessionConfig = $sessionConfig->withAccessMode($accessMode);
+        } elseif ($sessionConfig->getAccessMode() === null && $this->pool instanceof Neo4jConnectionPool) {
+            $sessionConfig = $sessionConfig->withAccessMode(AccessMode::WRITE());
+        }
+
+        $tsx = $this->startTransaction($config, $sessionConfig);
         $tsx->runStatements($statements ?? []);
 
         return $tsx;
@@ -351,11 +480,13 @@ final class Session implements SessionInterface
         /** @var ConnectionPoolInterface<\Laudis\Neo4j\Contracts\ConnectionInterface>|null $pool */
         $pool = $this->pool;
 
+        $sessionConfig = $this->getSessionConfiguration();
+
         return new BoltUnmanagedTransaction(
-            $this->config->getDatabase(),
+            $sessionConfig->getDatabase(),
             $this->formatter,
             $connection,
-            $this->config,
+            $sessionConfig,
             $tsxConfig,
             $this->bookmarkHolder,
             new BoltMessageFactory($connection, $this->getLogger()),
@@ -402,11 +533,13 @@ final class Session implements SessionInterface
         /** @var ConnectionPoolInterface<\Laudis\Neo4j\Contracts\ConnectionInterface>|null $pool */
         $pool = $this->pool;
 
+        $effectiveSessionConfig = $this->resolveTransactionSessionConfiguration($sessionConfig);
+
         return new BoltUnmanagedTransaction(
-            $this->config->getDatabase(),
+            $effectiveSessionConfig->getDatabase(),
             $this->formatter,
             $connection,
-            $this->config,
+            $effectiveSessionConfig,
             $config,
             $this->bookmarkHolder,
             new BoltMessageFactory($connection, $this->getLogger()),
@@ -414,6 +547,38 @@ final class Session implements SessionInterface
             $pool,
             false, // BEGIN sent on first run/commit/rollback
         );
+    }
+
+    private function resolveTransactionSessionConfiguration(SessionConfiguration $sessionConfig): SessionConfiguration
+    {
+        $effective = $this->getSessionConfiguration();
+
+        if ($sessionConfig->getAccessMode() !== null) {
+            $effective = $effective->withAccessMode($sessionConfig->getAccessMode());
+        }
+
+        return $effective;
+    }
+
+    /**
+     * Aura often exposes followers that cannot serve the user database; route reads to the leader.
+     */
+    private function resolveRoutingAccessMode(bool $read): AccessMode
+    {
+        if ($read && $this->isAuraHost()) {
+            return AccessMode::WRITE();
+        }
+
+        return $read ? AccessMode::READ() : AccessMode::WRITE();
+    }
+
+    private function isAuraHost(): bool
+    {
+        if (!$this->pool instanceof Neo4jConnectionPool) {
+            return false;
+        }
+
+        return str_ends_with(strtolower($this->pool->getHost()), '.databases.neo4j.io');
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -98,7 +98,15 @@ final class Client implements ClientInterface
             return $this->boundSessions[$alias];
         }
 
-        return $this->boundSessions[$alias] = $this->startSession($alias, $this->defaultSessionConfiguration);
+        return $this->boundSessions[$alias] = $this->startSession(
+            $alias,
+            $this->resolveSessionConfiguration($this->defaultSessionConfiguration, $alias)
+        );
+    }
+
+    private function resolveSessionConfiguration(SessionConfiguration $config, ?string $alias = null): SessionConfiguration
+    {
+        return $config;
     }
 
     /**
@@ -123,7 +131,8 @@ final class Client implements ClientInterface
 
         while ($tries > 0) {
             try {
-                $driver = $this->driverSetups->getDriver($this->defaultSessionConfiguration, $alias);
+                $sessionConfig = $this->resolveSessionConfiguration($this->defaultSessionConfiguration, $alias);
+                $driver = $this->driverSetups->getDriver($sessionConfig, $alias);
 
                 $driverHash = spl_object_hash($driver);
                 if (in_array($driverHash, $attemptedDrivers, true)) {
@@ -131,7 +140,7 @@ final class Client implements ClientInterface
                 }
                 $attemptedDrivers[] = $driverHash;
 
-                $session = $driver->createSession($this->defaultSessionConfiguration);
+                $session = $driver->createSession($sessionConfig);
 
                 return $operation($session);
             } catch (ConnectionPoolException|ConnectException $e) {
@@ -190,12 +199,17 @@ final class Client implements ClientInterface
 
     public function getDriver(?string $alias): DriverInterface
     {
-        return $this->driverSetups->getDriver($this->defaultSessionConfiguration, $alias);
+        return $this->driverSetups->getDriver(
+            $this->resolveSessionConfiguration($this->defaultSessionConfiguration, $alias),
+            $alias
+        );
     }
 
     private function startSession(?string $alias, SessionConfiguration $configuration): SessionInterface
     {
-        return $this->getDriver($alias)->createSession($configuration);
+        return $this->getDriver($alias)->createSession(
+            $this->resolveSessionConfiguration($configuration, $alias)
+        );
     }
 
     public function writeTransaction(callable $tsxHandler, ?string $alias = null, ?TransactionConfiguration $config = null)
@@ -239,7 +253,10 @@ final class Client implements ClientInterface
 
     public function verifyConnectivity(?string $driver = null): bool
     {
-        return $this->driverSetups->verifyConnectivity($this->defaultSessionConfiguration, $driver);
+        return $this->driverSetups->verifyConnectivity(
+            $this->resolveSessionConfiguration($this->defaultSessionConfiguration, $driver),
+            $driver
+        );
     }
 
     public function hasDriver(string $alias): bool

--- a/src/Common/DriverSetupManager.php
+++ b/src/Common/DriverSetupManager.php
@@ -176,6 +176,21 @@ class DriverSetupManager implements Countable
         return $this->decideAlias(null);
     }
 
+    public function getUriHostForAlias(?string $alias = null): ?string
+    {
+        $alias ??= $this->getDefaultAlias();
+
+        if (!array_key_exists($alias, $this->driverSetups)) {
+            return null;
+        }
+
+        foreach ($this->driverSetups[$alias] as $setup) {
+            return $setup->getUri()->getHost();
+        }
+
+        return null;
+    }
+
     /**
      * @psalm-mutation-free
      */

--- a/src/Contracts/SessionInterface.php
+++ b/src/Contracts/SessionInterface.php
@@ -49,6 +49,20 @@ interface SessionInterface extends TransactionInterface
     public function beginTransaction(?iterable $statements = null, ?TransactionConfiguration $config = null): UnmanagedTransactionInterface;
 
     /**
+     * @psalm-param iterable<Statement>|null $statements
+     *
+     * @throws Neo4jException
+     */
+    public function beginWriteTransaction(?iterable $statements = null, ?TransactionConfiguration $config = null): UnmanagedTransactionInterface;
+
+    /**
+     * @psalm-param iterable<Statement>|null $statements
+     *
+     * @throws Neo4jException
+     */
+    public function beginReadTransaction(?iterable $statements = null, ?TransactionConfiguration $config = null): UnmanagedTransactionInterface;
+
+    /**
      * @template HandlerResult
      *
      * @param callable(TransactionInterface):HandlerResult $tsxHandler

--- a/src/Databags/SessionConfiguration.php
+++ b/src/Databags/SessionConfiguration.php
@@ -160,6 +160,38 @@ final class SessionConfiguration
     }
 
     /**
+     * On Aura (*.databases.neo4j.io), the default name "neo4j" is not a valid database.
+     * Do not strip the hostname instance id here — on many Aura instances that *is* the
+     * real database name. A wrong instance-id-only .env value is cleared on DatabaseNotFound retry.
+     */
+    public static function normalizeAuraDatabaseName(?string $database, ?string $host): ?string
+    {
+        if ($database === null || $host === null || $host === '') {
+            return $database;
+        }
+
+        if (!str_ends_with(strtolower($host), '.databases.neo4j.io')) {
+            return $database;
+        }
+
+        if ($database === self::DEFAULT_DATABASE) {
+            return null;
+        }
+
+        return $database;
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function withAuraNormalizedDatabase(string $host): self
+    {
+        $normalized = self::normalizeAuraDatabaseName($this->database, $host);
+
+        return $normalized === $this->database ? $this : $this->withDatabase($normalized);
+    }
+
+    /**
      * Creates a session configuration from the information found within the uri.
      *
      * @pure

--- a/src/Neo4j/HomeDatabaseCache.php
+++ b/src/Neo4j/HomeDatabaseCache.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Neo4j;
+
+/**
+ * Process-wide cache of the home database name returned by ROUTE for a cluster host.
+ *
+ * When the session has no database set, subsequent routing table lookups reuse this
+ * value so the driver does not need to resolve the home database on every request.
+ */
+final class HomeDatabaseCache
+{
+    /** @var array<string, string> */
+    private static array $cache = [];
+
+    public static function get(string $host): ?string
+    {
+        return self::$cache[$host] ?? null;
+    }
+
+    public static function set(string $host, string $database): void
+    {
+        self::$cache[$host] = $database;
+    }
+
+    public static function clear(string $host): void
+    {
+        unset(self::$cache[$host]);
+    }
+
+    public static function clearAll(): void
+    {
+        self::$cache = [];
+    }
+}

--- a/src/Neo4j/Neo4jConnectionPool.php
+++ b/src/Neo4j/Neo4jConnectionPool.php
@@ -127,7 +127,11 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
      */
     public function acquire(SessionConfiguration $config): Generator
     {
-        $key = $this->createKey($this->data, $config);
+        $host = $this->data->getUri()->getHost();
+        // Strip invalid Aura default "neo4j" for ROUTE; keep explicit names (including instance id when that is the DB name).
+        $routeConfig = $config->withAuraNormalizedDatabase($host);
+        $routingConfig = $this->resolveRoutingSessionConfiguration($routeConfig, $config);
+        $key = $this->createKey($this->data, $routingConfig);
 
         /** @var RoutingTable|null $table */
         $table = $this->cache->get($key);
@@ -152,8 +156,8 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
                      *
                      * @psalm-suppress UnnecessaryVarAnnotation
                      */
-                    $connection = GeneratorHelper::getReturnFromGenerator($pool->acquire($config));
-                    $table = $this->routingTable($connection, $config);
+                    $connection = GeneratorHelper::getReturnFromGenerator($pool->acquire($routeConfig));
+                    $table = $this->routingTable($connection, $routeConfig);
 
                     $this->getLogger()?->log(LogLevel::DEBUG, 'Successfully fetched routing table', [
                         'ttl' => $table->getTtl(),
@@ -170,7 +174,7 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
                     continue; // We continue if something is wrong with the current server
                 }
 
-                $this->cache->set($key, $table, $table->getTtl());
+                $this->cacheRoutingTable($key, $table, $routeConfig);
                 // TODO: release probably logs off the connection, it is not preferable
                 $pool->release($connection);
 
@@ -228,6 +232,23 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
             'key' => $key,
             'deleted' => $deleted,
         ]);
+    }
+
+    /**
+     * Clears all cached routing tables and home-database hints for this driver's host.
+     */
+    public function invalidateRoutingForHost(): void
+    {
+        $host = $this->data->getUri()->getHost();
+        HomeDatabaseCache::clear($host);
+        $this->cache->clear();
+
+        $this->getLogger()?->log(LogLevel::INFO, 'Invalidated routing cache for host', ['host' => $host]);
+    }
+
+    public function getHost(): string
+    {
+        return $this->data->getUri()->getHost();
     }
 
     /**
@@ -309,11 +330,27 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
     {
         $bolt = $connection->protocol();
 
-        $this->getLogger()?->log(LogLevel::DEBUG, 'ROUTE', ['db' => $config->getDatabase()]);
-        /** @var array{rt: array{servers: list<array{addresses: list<string>, role:string}>, ttl: int}} $route */
-        $route = $bolt->route([], [], ['db' => $config->getDatabase()])
+        $database = $config->getDatabase();
+        $this->getLogger()?->log(LogLevel::DEBUG, 'ROUTE', ['db' => $database]);
+        /** @var array{rt?: array{servers: list<array{addresses: list<string>, role:string}>, ttl: int}, db?: string} $route */
+        $route = $bolt->route([], [], self::buildRouteExtra($database))
             ->getResponse()
             ->content;
+
+        if (!isset($route['rt']) || !is_array($route['rt'])) {
+            $databaseHint = $database ?? '(home database)';
+
+            throw new RuntimeException(sprintf(
+                'Invalid ROUTE response: missing routing table for database %s. '
+                .'On Aura, do not use database name "neo4j"; omit the database or use the name from SHOW DATABASES.',
+                $databaseHint
+            ));
+        }
+
+        if (isset($route['db']) && $route['db'] !== '') {
+            HomeDatabaseCache::set($this->data->getUri()->getHost(), $route['db']);
+            $this->getLogger()?->log(LogLevel::DEBUG, 'Cached home database from ROUTE', ['db' => $route['db']]);
+        }
 
         ['servers' => $servers, 'ttl' => $ttl] = $route['rt'];
         $ttl += time();
@@ -326,6 +363,63 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
         $this->createOrGetPool($connection->getServerAddress()->getHost(), $connection->getServerAddress())->release(
             $connection
         );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function buildRouteExtra(?string $database): array
+    {
+        if ($database === null) {
+            return [];
+        }
+
+        return ['db' => $database];
+    }
+
+    /**
+     * When the session has no database, reuse the cached home DB for routing table lookup.
+     */
+    private function resolveRoutingSessionConfiguration(SessionConfiguration $routeConfig, SessionConfiguration $sessionConfig): SessionConfiguration
+    {
+        if ($routeConfig->getDatabase() !== null) {
+            return $routeConfig;
+        }
+
+        $normalizedSession = $sessionConfig->withAuraNormalizedDatabase($this->data->getUri()->getHost());
+        if ($normalizedSession->getDatabase() !== null) {
+            return $routeConfig->withDatabase($normalizedSession->getDatabase());
+        }
+
+        $cachedHomeDatabase = HomeDatabaseCache::get($this->data->getUri()->getHost());
+        if ($cachedHomeDatabase === null) {
+            return $routeConfig;
+        }
+
+        return $routeConfig->withDatabase($cachedHomeDatabase);
+    }
+
+    private function cacheRoutingTable(
+        string $key,
+        RoutingTable $table,
+        SessionConfiguration $config,
+    ): void {
+        $ttl = $table->getTtl();
+        $this->cache->set($key, $table, $ttl);
+
+        if ($config->getDatabase() !== null) {
+            return;
+        }
+
+        $homeDatabase = HomeDatabaseCache::get($this->data->getUri()->getHost());
+        if ($homeDatabase === null) {
+            return;
+        }
+
+        $homeKey = $this->createKey($this->data, $config->withDatabase($homeDatabase));
+        if ($homeKey !== $key) {
+            $this->cache->set($homeKey, $table, $ttl);
+        }
     }
 
     private function createKey(ConnectionRequestData $data, ?SessionConfiguration $config = null): string
@@ -365,6 +459,17 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
         }
         self::$pools = [];
         $this->cache->clear();
+    }
+
+    /**
+     * Closes every shared sub-pool. Useful for tests and when resetting routing state.
+     */
+    public static function closeAll(): void
+    {
+        foreach (self::$pools as $pool) {
+            $pool->close();
+        }
+        self::$pools = [];
     }
 
     /**

--- a/src/Neo4j/Neo4jDriver.php
+++ b/src/Neo4j/Neo4jDriver.php
@@ -91,8 +91,11 @@ final class Neo4jDriver implements DriverInterface
     public function verifyConnectivity(?SessionConfiguration $config = null): bool
     {
         $config ??= SessionConfiguration::default();
+        $config = $config->merge(SessionConfiguration::fromUri($this->parsedUrl, $this->pool->getLogger()));
+
         try {
-            GeneratorHelper::getReturnFromGenerator($this->pool->acquire($config));
+            $connection = GeneratorHelper::getReturnFromGenerator($this->pool->acquire($config));
+            $this->pool->release($connection);
         } catch (ConnectException|ConnectionPoolException $e) {
             $this->pool->getLogger()?->log(LogLevel::WARNING, 'Could not connect to server on URI '.$this->parsedUrl->__toString(), ['error' => $e]);
 
@@ -105,6 +108,7 @@ final class Neo4jDriver implements DriverInterface
     public function getServerInfo(?SessionConfiguration $config = null): ServerInfo
     {
         $config ??= SessionConfiguration::default();
+        $config = $config->merge(SessionConfiguration::fromUri($this->parsedUrl, $this->pool->getLogger()));
 
         // Use READ access mode to connect to a follower (read server)
         if ($config->getAccessMode() === null) {

--- a/test-aura-database-info.php
+++ b/test-aura-database-info.php
@@ -1,0 +1,206 @@
+<?php
+
+require 'vendor/autoload.php';
+
+use Laudis\Neo4j\Authentication\Authenticate;
+use Laudis\Neo4j\ClientBuilder;
+use Laudis\Neo4j\Databags\SessionConfiguration;
+use Laudis\Neo4j\Neo4j\HomeDatabaseCache;
+
+/**
+ * @param array<string, string> $env
+ */
+function loadEnvFile(string $path, array &$env = []): void
+{
+    if (!is_readable($path)) {
+        return;
+    }
+
+    foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+        $line = trim($line);
+        if ($line === '' || str_starts_with($line, '#')) {
+            continue;
+        }
+
+        if (!str_contains($line, '=')) {
+            continue;
+        }
+
+        [$name, $value] = explode('=', $line, 2);
+        $name = trim($name);
+        $value = trim($value, " \t\n\r\0\x0B\"'");
+
+        $env[$name] = $value;
+        $_ENV[$name] = $value;
+        putenv($name.'='.$value);
+    }
+}
+
+loadEnvFile(__DIR__.'/.env');
+
+$uri = $_ENV['NEO4J_URI'];
+$username = $_ENV['NEO4J_USERNAME'];
+$password = $_ENV['NEO4J_PASSWORD'];
+
+echo "=====================================\n";
+echo "Aura Connection Information\n";
+echo "=====================================\n";
+
+echo "URI: {$uri}\n";
+echo "Username: {$username}\n";
+echo "ENV Database: " . ($_ENV['NEO4J_DATABASE'] ?? 'not set') . "\n";
+
+$auraHost = parse_url($uri, PHP_URL_HOST);
+if (is_string($auraHost)) {
+    HomeDatabaseCache::clear($auraHost);
+}
+
+echo "\n=====================================\n";
+echo "TEST 1 - Basic Connectivity\n";
+echo "=====================================\n";
+
+try {
+
+    $client = ClientBuilder::create()
+        ->withDriver(
+            'default',
+            $uri,
+            Authenticate::basic($username, $password)
+        )
+        ->withDefaultSessionConfiguration(
+            SessionConfiguration::default()
+                ->withDatabase($_ENV['NEO4J_DATABASE'] ?? null)
+        )
+        ->build();
+
+    var_dump($client->verifyConnectivity());
+
+} catch (Throwable $e) {
+
+    echo "Connectivity FAILED:\n";
+    echo $e->getMessage() . "\n";
+
+    exit(1);
+}
+
+echo "\n=====================================\n";
+echo "TEST 2 - Simple Query Without Explicit DB\n";
+echo "=====================================\n";
+
+try {
+
+    $result = $client->run('RETURN 1 AS test');
+
+    foreach ($result as $record) {
+        var_dump($record);
+    }
+
+} catch (Throwable $e) {
+
+    echo "Simple query FAILED:\n";
+    echo $e->getMessage() . "\n";
+}
+
+echo "\n=====================================\n";
+echo "TEST 3 - Database Info\n";
+echo "=====================================\n";
+
+try {
+
+    $result = $client->run('CALL db.info()');
+
+    foreach ($result as $record) {
+        var_dump($record);
+    }
+
+} catch (Throwable $e) {
+
+    echo "db.info() FAILED:\n";
+    echo $e->getMessage() . "\n";
+}
+
+echo "\n=====================================\n";
+echo "TEST 4 - SHOW DATABASES\n";
+echo "=====================================\n";
+
+try {
+
+    $result = $client->run('SHOW DATABASES');
+
+    foreach ($result as $record) {
+        var_dump($record);
+    }
+
+} catch (Throwable $e) {
+
+    echo "SHOW DATABASES FAILED:\n";
+    echo $e->getMessage() . "\n";
+}
+
+echo "\n=====================================\n";
+echo "TEST 5 - Explicit database = ENV value\n";
+echo "=====================================\n";
+
+try {
+
+    $explicitDbClient = ClientBuilder::create()
+        ->withDriver(
+            'default',
+            $uri,
+            Authenticate::basic($username, $password)
+        )
+        ->withDefaultSessionConfiguration(
+            SessionConfiguration::default()
+                ->withDatabase($_ENV['NEO4J_DATABASE'])
+        )
+        ->build();
+
+    $result = $explicitDbClient->run(
+        'RETURN "explicit env db works" AS message'
+    );
+
+    foreach ($result as $record) {
+        var_dump($record);
+    }
+
+} catch (Throwable $e) {
+
+    echo "Explicit ENV DB FAILED:\n";
+    echo $e->getMessage() . "\n";
+}
+
+echo "\n=====================================\n";
+echo "TEST 6 - Explicit database = neo4j\n";
+echo "=====================================\n";
+
+try {
+
+    $neo4jClient = ClientBuilder::create()
+        ->withDriver(
+            'default',
+            $uri,
+            Authenticate::basic($username, $password)
+        )
+        ->withDefaultSessionConfiguration(
+            SessionConfiguration::default()
+                ->withDatabase('neo4j')
+        )
+        ->build();
+
+    $result = $neo4jClient->run(
+        'RETURN "neo4j db works" AS message'
+    );
+
+    foreach ($result as $record) {
+        var_dump($record);
+    }
+
+} catch (Throwable $e) {
+
+    echo "Explicit neo4j DB FAILED:\n";
+    echo $e->getMessage() . "\n";
+}
+
+echo "\n=====================================\n";
+echo "DONE\n";
+echo "=====================================\n";

--- a/test-aura-write-transaction.php
+++ b/test-aura-write-transaction.php
@@ -1,0 +1,270 @@
+<?php
+
+/**
+ * Aura regression script for managed transactions (writeTransaction / readTransaction).
+ *
+ * Mirrors a typical Laravel service-provider setup:
+ *   ClientBuilder + SessionConfiguration::default()->withDatabase($instanceId)
+ *
+ * Usage: php test-aura-write-transaction.php
+ *
+ * Requires .env: NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD, NEO4J_DATABASE (Aura instance id)
+ */
+
+require 'vendor/autoload.php';
+
+use Laudis\Neo4j\Authentication\Authenticate;
+use Laudis\Neo4j\ClientBuilder;
+use Laudis\Neo4j\Contracts\ClientInterface;
+use Laudis\Neo4j\Contracts\TransactionInterface;
+use Laudis\Neo4j\Databags\SessionConfiguration;
+use Laudis\Neo4j\Databags\Statement;
+use Laudis\Neo4j\Databags\TransactionConfiguration;
+use Laudis\Neo4j\Neo4j\HomeDatabaseCache;
+
+/**
+ * @param array<string, string> $env
+ */
+function loadEnvFile(string $path, array &$env = []): void
+{
+    if (!is_readable($path)) {
+        return;
+    }
+
+    foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+        $line = trim($line);
+        if ($line === '' || str_starts_with($line, '#')) {
+            continue;
+        }
+
+        if (!str_contains($line, '=')) {
+            continue;
+        }
+
+        [$name, $value] = explode('=', $line, 2);
+        $name = trim($name);
+        $value = trim($value, " \t\n\r\0\x0B\"'");
+
+        $env[$name] = $value;
+        $_ENV[$name] = $value;
+        putenv($name.'='.$value);
+    }
+}
+
+/**
+ * Same pattern as Laravel execute(): run() or managed transaction by write flag.
+ */
+function execute(ClientInterface $client, Statement $statement, bool $isWrite): mixed
+{
+    if (!$isWrite && preg_match('/\b(CREATE|MERGE|DELETE|SET|REMOVE)\b/i', $statement->getText())) {
+        $isWrite = true;
+    }
+
+    if (!$isWrite) {
+        return $client->run(
+            $statement->getText(),
+            $statement->getParameters()
+        );
+    }
+
+    $query = $statement->getText();
+    $params = $statement->getParameters();
+
+    return $client->writeTransaction(
+        static function (TransactionInterface $tsx) use ($query, $params) {
+            return $tsx->run($query, $params);
+        }
+    );
+}
+
+function pass(string $label): void
+{
+    echo "PASS  {$label}\n";
+}
+
+function fail(string $label, Throwable $e): void
+{
+    echo "FAIL  {$label}\n";
+    echo "      {$e->getMessage()}\n";
+}
+
+function section(string $title): void
+{
+    echo "\n=====================================\n";
+    echo "{$title}\n";
+    echo "=====================================\n";
+}
+
+loadEnvFile(__DIR__.'/.env');
+
+$uri = $_ENV['NEO4J_URI'] ?? null;
+$username = $_ENV['NEO4J_USERNAME'] ?? null;
+$password = $_ENV['NEO4J_PASSWORD'] ?? null;
+$database = $_ENV['NEO4J_DATABASE'] ?? null;
+
+if (!is_string($uri) || !is_string($username) || !is_string($password)) {
+    fwrite(STDERR, "Missing NEO4J_URI, NEO4J_USERNAME, or NEO4J_PASSWORD in .env\n");
+    exit(1);
+}
+
+$auraHost = parse_url($uri, PHP_URL_HOST);
+if (is_string($auraHost)) {
+    HomeDatabaseCache::clear($auraHost);
+}
+
+$label = 'AuraWriteTxTest_'.bin2hex(random_bytes(4));
+
+section('Configuration');
+echo "URI: {$uri}\n";
+echo "Database: ".($database ?? '(not set)')."\n";
+echo "Test label: {$label}\n";
+
+$timeout = (int) ($_ENV['NEO4J_TIMEOUT'] ?? 300);
+$fetchSize = (int) ($_ENV['NEO4J_FETCH_SIZE'] ?? 1000);
+
+$sessionConfig = SessionConfiguration::default()
+    ->withFetchSize($fetchSize);
+
+if ($database !== null && $database !== '') {
+    $sessionConfig = $sessionConfig->withDatabase($database);
+}
+
+$client = ClientBuilder::create()
+    ->withDriver('default', $uri, Authenticate::basic($username, $password))
+    ->withDefaultTransactionConfiguration(
+        TransactionConfiguration::default()->withTimeout($timeout)
+    )
+    ->withDefaultSessionConfiguration($sessionConfig)
+    ->build();
+
+$failed = 0;
+
+section('Connectivity');
+try {
+    if ($client->verifyConnectivity() !== true) {
+        throw new RuntimeException('verifyConnectivity() returned false');
+    }
+    pass('verifyConnectivity()');
+} catch (Throwable $e) {
+    fail('verifyConnectivity()', $e);
+    exit(1);
+}
+
+section('writeTransaction() — CREATE');
+try {
+    $result = $client->writeTransaction(
+        static function (TransactionInterface $tsx) use ($label) {
+            return $tsx->run(
+                'CREATE (n:AuraWriteTxTest {label: $label}) RETURN n.label AS label',
+                ['label' => $label]
+            );
+        }
+    );
+    $created = $result->first()->get('label');
+    if ($created !== $label) {
+        throw new RuntimeException("Expected label {$label}, got {$created}");
+    }
+    pass('writeTransaction CREATE');
+} catch (Throwable $e) {
+    fail('writeTransaction CREATE', $e);
+    ++$failed;
+}
+
+section('readTransaction() — MATCH');
+try {
+    $result = $client->readTransaction(
+        static function (TransactionInterface $tsx) use ($label) {
+            return $tsx->run(
+                'MATCH (n:AuraWriteTxTest {label: $label}) RETURN count(n) AS c',
+                ['label' => $label]
+            );
+        }
+    );
+    $count = $result->first()->get('c');
+    if ((int) $count < 1) {
+        throw new RuntimeException("Expected at least 1 node, got {$count}");
+    }
+    pass("readTransaction MATCH (count={$count})");
+} catch (Throwable $e) {
+    fail('readTransaction MATCH', $e);
+    ++$failed;
+}
+
+section('run() — read');
+try {
+    $result = $client->run(
+        'MATCH (n:AuraWriteTxTest {label: $label}) RETURN count(n) AS c',
+        ['label' => $label]
+    );
+    $count = $result->first()->get('c');
+    if ((int) $count < 1) {
+        throw new RuntimeException("Expected at least 1 node, got {$count}");
+    }
+    pass("run() read (count={$count})");
+} catch (Throwable $e) {
+    fail('run() read', $e);
+    ++$failed;
+}
+
+section('execute() helper — write via writeTransaction');
+try {
+    $result = execute(
+        $client,
+        new Statement(
+            'MATCH (n:AuraWriteTxTest {label: $label}) SET n.checked = true RETURN n.checked AS checked',
+            ['label' => $label]
+        ),
+        true
+    );
+    if ($result->first()->get('checked') !== true) {
+        throw new RuntimeException('SET did not persist checked=true');
+    }
+    pass('execute() write path');
+} catch (Throwable $e) {
+    fail('execute() write path', $e);
+    ++$failed;
+}
+
+section('execute() helper — read via run()');
+try {
+    $result = execute(
+        $client,
+        new Statement(
+            'MATCH (n:AuraWriteTxTest {label: $label}) RETURN n.checked AS checked',
+            ['label' => $label]
+        ),
+        false
+    );
+    if ($result->first()->get('checked') !== true) {
+        throw new RuntimeException('Expected checked=true after SET');
+    }
+    pass('execute() read path');
+} catch (Throwable $e) {
+    fail('execute() read path', $e);
+    ++$failed;
+}
+
+section('Cleanup');
+try {
+    $deleted = $client->writeTransaction(
+        static function (TransactionInterface $tsx) use ($label) {
+            return $tsx->run(
+                'MATCH (n:AuraWriteTxTest {label: $label}) DETACH DELETE n RETURN count(n) AS deleted',
+                ['label' => $label]
+            );
+        }
+    );
+    pass('cleanup DETACH DELETE (deleted='.$deleted->first()->get('deleted').')');
+} catch (Throwable $e) {
+    fail('cleanup', $e);
+    ++$failed;
+}
+
+section('Summary');
+if ($failed === 0) {
+    echo "All tests passed.\n";
+    exit(0);
+}
+
+echo "{$failed} test(s) failed.\n";
+exit(1);

--- a/testkit-backend/src/Handlers/SessionBeginTransaction.php
+++ b/testkit-backend/src/Handlers/SessionBeginTransaction.php
@@ -62,7 +62,6 @@ final class SessionBeginTransaction implements RequestHandlerInterface
             $config = $config->withMetaData($actualMeta);
         }
 
-        // TODO - Create beginReadTransaction and beginWriteTransaction
         try {
             $transaction = $session->beginTransaction(null, $config);
         } catch (Neo4jException $exception) {

--- a/testkit-backend/src/Handlers/SessionReadTransaction.php
+++ b/testkit-backend/src/Handlers/SessionReadTransaction.php
@@ -61,8 +61,7 @@ final class SessionReadTransaction implements RequestHandlerInterface
 
         $id = Uuid::v4();
         try {
-            // TODO - Create beginReadTransaction and beginWriteTransaction
-            $transaction = $session->beginTransaction(null, $config);
+            $transaction = $session->beginReadTransaction(null, $config);
 
             $this->repository->addTransaction($id, $transaction);
             $this->repository->bindTransactionToSession($request->getSessionId(), $id);

--- a/testkit-backend/src/Handlers/SessionWriteTransaction.php
+++ b/testkit-backend/src/Handlers/SessionWriteTransaction.php
@@ -61,8 +61,7 @@ final class SessionWriteTransaction implements RequestHandlerInterface
 
         $id = Uuid::v4();
         try {
-            // TODO - Create beginReadTransaction and beginWriteTransaction
-            $transaction = $session->beginTransaction(null, $config);
+            $transaction = $session->beginWriteTransaction(null, $config);
 
             $this->repository->addTransaction($id, $transaction);
             $this->repository->bindTransactionToSession($request->getSessionId(), $id);


### PR DESCRIPTION

- Fixes `DatabaseNotFound` on Neo4j Aura (`neo4j+s://`) for `writeTransaction()` / `readTransaction()` when using instance-ID databases — driver routing bug in 3.4.3, not Laravel/app config.
- Adds `HomeDatabaseCache` to store the home database from Bolt `ROUTE` and reuse it for later routing table lookups.
- Normalizes Aura database names in `SessionConfiguration` (literal `neo4j` → unset; instance ID kept when valid).
- Updates `Neo4jConnectionPool` and `Bolt\Session` for Aura-aware routing keys, cache invalidation, `DatabaseNotFound` retry, and correct access mode on managed transactions.
- Adds Aura regression scripts and `composer.laravel-private.example.json` for testing and private Composer installs until release.