### PR TITLE
Main implementation of Bolt 5.4 telemetry and executeQuery, including Aura integration tests and README updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,26 @@ A driver, session and transaction can be configured using configuration objects.
 | bookmarks         | session     | The bookmarks used in the session. (experimental)                                | `SessionConfiguration`     |
 | metadata          | transaction | The metadata used during the transaction. (experimental)                         | `TransactionConfiguration` |
 | timeout           | transaction | The maximum amount of time before timing out.                                    | `TransactionConfiguration` |
+| telemetry disabled | driver     | Opt out of anonymous Bolt API usage telemetry (Bolt 5.4). Default: enabled.      | `DriverConfiguration`      |
+
+### Bolt API telemetry (Bolt 5.4+)
+
+When the server advertises `telemetry.enabled` in the HELLO/LOGON response (for example on Aura), the driver may send a single anonymous integer per API category per connection, immediately before `BEGIN` or `RUN`. This helps Neo4j understand which driver APIs are used in production. No query text, parameters, or user data are transmitted.
+
+| Value | API |
+|-------|-----|
+| 0 | Managed transactions (`readTransaction` / `writeTransaction`) |
+| 1 | Explicit transactions (`beginTransaction`) |
+| 2 | Autocommit (`session.run`) |
+| 3 | Driver-level (`executeQuery`) |
+
+Telemetry is sent only when enabled on **both** server and driver. Disable it on the driver with:
+
+```php
+use Laudis\Neo4j\Databags\DriverConfiguration;
+
+$config = DriverConfiguration::default()->withTelemetryDisabled(true);
+```
 
 Code Example:
 

--- a/src/Authentication/BasicAuth.php
+++ b/src/Authentication/BasicAuth.php
@@ -35,7 +35,7 @@ final class BasicAuth implements AuthenticateInterface
     /**
      * @throws Exception
      *
-     * @return array{server: string, connection_id: string, hints: list}
+     * @return array{server: string, connection_id: string, hints: array<string, mixed>}
      */
     public function authenticateBolt(BoltConnection $connection, string $userAgent): array
     {
@@ -55,8 +55,7 @@ final class BasicAuth implements AuthenticateInterface
 
             $response = $factory->createLogonMessage($credentials)->send()->getResponse();
 
-            /** @var array{server: string, connection_id: string, hints: list} */
-            return array_merge($responseHello->content, $response->content);
+            return BoltAuthResponse::normalize(array_merge($responseHello->content, $response->content));
         }
 
         $helloMetadata = [
@@ -68,8 +67,7 @@ final class BasicAuth implements AuthenticateInterface
 
         $response = $factory->createHelloMessage($helloMetadata)->send()->getResponse();
 
-        /** @var array{server: string, connection_id: string, hints: list} */
-        return $response->content;
+        return BoltAuthResponse::normalize($response->content);
     }
 
     /**

--- a/src/Authentication/BoltAuthResponse.php
+++ b/src/Authentication/BoltAuthResponse.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Authentication;
+
+/**
+ * Normalizes Bolt SUCCESS metadata from the underlying bolt library into a stable shape.
+ */
+final class BoltAuthResponse
+{
+    /**
+     * @param array<array-key, mixed> $content
+     *
+     * @return array{server: string, connection_id: string, hints: array<string, mixed>}
+     */
+    public static function normalize(array $content): array
+    {
+        return [
+            'server' => array_key_exists('server', $content) && is_string($content['server']) ? $content['server'] : '',
+            'connection_id' => array_key_exists('connection_id', $content) && is_string($content['connection_id']) ? $content['connection_id'] : '',
+            'hints' => self::normalizeHints($content['hints'] ?? null),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function normalizeHints(mixed $rawHints): array
+    {
+        if (!is_array($rawHints)) {
+            return [];
+        }
+
+        $normalizedHints = [];
+        foreach ($rawHints as $key => $value) {
+            if (!is_string($key) || !self::isSupportedHintValue($value)) {
+                continue;
+            }
+
+            $normalizedHints[$key] = $value;
+        }
+
+        return $normalizedHints;
+    }
+
+    /**
+     * @psalm-assert-if-true bool|float|int|string|array|null $value
+     */
+    private static function isSupportedHintValue(mixed $value): bool
+    {
+        return is_scalar($value) || $value === null || is_array($value);
+    }
+}

--- a/src/Authentication/KerberosAuth.php
+++ b/src/Authentication/KerberosAuth.php
@@ -37,7 +37,7 @@ final class KerberosAuth implements AuthenticateInterface
     /**
      * @throws Exception
      *
-     * @return array{server: string, connection_id: string, hints: list}
+     * @return array{server: string, connection_id: string, hints: array<string, mixed>}
      */
     public function authenticateBolt(BoltConnection $connection, string $userAgent): array
     {
@@ -55,10 +55,7 @@ final class KerberosAuth implements AuthenticateInterface
             'credentials' => $this->token,
         ])->send()->getResponse();
 
-        /**
-         * @var array{server: string, connection_id: string, hints: list}
-         */
-        return $response->content;
+        return BoltAuthResponse::normalize($response->content);
     }
 
     public function toString(UriInterface $uri): string

--- a/src/Authentication/NoAuth.php
+++ b/src/Authentication/NoAuth.php
@@ -33,7 +33,7 @@ final class NoAuth implements AuthenticateInterface
     /**
      * @throws Exception
      *
-     * @return array{server: string, connection_id: string, hints: list}
+     * @return array{server: string, connection_id: string, hints: array<string, mixed>}
      */
     public function authenticateBolt(BoltConnection $connection, string $userAgent): array
     {
@@ -46,8 +46,7 @@ final class NoAuth implements AuthenticateInterface
 
             $response = $factory->createLogonMessage(['scheme' => 'none'])->send()->getResponse();
 
-            /** @var array{server: string, connection_id: string, hints: list} */
-            return $response->content;
+            return BoltAuthResponse::normalize($response->content);
         }
 
         $helloMetadata = [
@@ -57,8 +56,7 @@ final class NoAuth implements AuthenticateInterface
 
         $response = $factory->createHelloMessage($helloMetadata)->send()->getResponse();
 
-        /** @var array{server: string, connection_id: string, hints: list} */
-        return $response->content;
+        return BoltAuthResponse::normalize($response->content);
     }
 
     public function toString(UriInterface $uri): string

--- a/src/Authentication/OpenIDConnectAuth.php
+++ b/src/Authentication/OpenIDConnectAuth.php
@@ -43,7 +43,7 @@ class OpenIDConnectAuth implements AuthenticateInterface
     /**
      * @throws Exception
      *
-     * @return array{server: string, connection_id: string, hints: list}
+     * @return array{server: string, connection_id: string, hints: array<string, mixed>}
      */
     public function authenticateBolt(BoltConnection $connection, string $userAgent): array
     {
@@ -60,10 +60,7 @@ class OpenIDConnectAuth implements AuthenticateInterface
             'credentials' => $this->token,
         ])->send()->getResponse();
 
-        /**
-         * @var array{server: string, connection_id: string, hints: list}
-         */
-        return $response->content;
+        return BoltAuthResponse::normalize($response->content);
     }
 
     public function toString(UriInterface $uri): string

--- a/src/Bolt/BoltConnection.php
+++ b/src/Bolt/BoltConnection.php
@@ -33,6 +33,7 @@ use Laudis\Neo4j\Databags\DatabaseInfo;
 use Laudis\Neo4j\Databags\DriverConfiguration;
 use Laudis\Neo4j\Databags\Neo4jError;
 use Laudis\Neo4j\Enum\AccessMode;
+use Laudis\Neo4j\Enum\BoltTelemetryApi;
 use Laudis\Neo4j\Enum\ConnectionProtocol;
 use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
@@ -71,6 +72,13 @@ class BoltConnection implements ConnectionInterface
 
     private ?float $originalTimeout = null;
 
+    private bool $serverTelemetryEnabled = false;
+
+    /** @var array<int, true> */
+    private array $acknowledgedTelemetryApis = [];
+
+    private ?BoltTelemetryApi $pendingTelemetryApi = null;
+
     /**
      * @return array{0: V4_4|V5|V5_1|V5_2|V5_3|V5_4|null, 1: Connection}
      */
@@ -91,8 +99,46 @@ class BoltConnection implements ConnectionInterface
         private readonly ConnectionConfiguration $config,
         private readonly ?Neo4jLogger $logger,
         private readonly float $defaultRecvTimeout = DriverConfiguration::DEFAULT_SOCKET_TIMEOUT,
+        private readonly bool $driverTelemetryDisabled = false,
     ) {
         $this->messageFactory = new BoltMessageFactory($this, $this->logger);
+    }
+
+    public function setServerTelemetryEnabled(bool $enabled): void
+    {
+        $this->serverTelemetryEnabled = $enabled;
+    }
+
+    /**
+     * Sends a TELEMETRY message once per API type per connection when enabled by server and driver.
+     * Resends on failure until SUCCESS is received; never sends again after success.
+     */
+    public function sendTelemetryIfNeeded(BoltTelemetryApi $api): void
+    {
+        if ($this->driverTelemetryDisabled || !$this->serverTelemetryEnabled) {
+            return;
+        }
+
+        if (!$this->protocol() instanceof V5_4) {
+            return;
+        }
+
+        if (isset($this->acknowledgedTelemetryApis[$api->value])) {
+            return;
+        }
+
+        $this->messageFactory->createTelemetryMessage($api)->send();
+        $this->pendingTelemetryApi = $api;
+    }
+
+    public function acknowledgePendingTelemetry(): void
+    {
+        if ($this->pendingTelemetryApi === null) {
+            return;
+        }
+
+        $this->acknowledgedTelemetryApis[$this->pendingTelemetryApi->value] = true;
+        $this->pendingTelemetryApi = null;
     }
 
     public function getEncryptionLevel(): string
@@ -238,6 +284,7 @@ class BoltConnection implements ConnectionInterface
         $message = $this->messageFactory->createBeginMessage($extra);
         $response = $message->send()->getResponse();
         $this->assertNoFailure($response);
+        $this->acknowledgePendingTelemetry();
     }
 
     /**
@@ -274,6 +321,7 @@ class BoltConnection implements ConnectionInterface
         $message = $this->messageFactory->createRunMessage($text, $parameters, $extra);
         $response = $message->send()->getResponse();
         $this->assertNoFailure($response);
+        $this->acknowledgePendingTelemetry();
 
         /** @var BoltMeta */
         return $response->content;

--- a/src/Bolt/BoltConnection.php
+++ b/src/Bolt/BoltConnection.php
@@ -109,6 +109,11 @@ class BoltConnection implements ConnectionInterface
         $this->serverTelemetryEnabled = $enabled;
     }
 
+    public function isServerTelemetryEnabled(): bool
+    {
+        return $this->serverTelemetryEnabled;
+    }
+
     /**
      * Sends a TELEMETRY message once per API type per connection when enabled by server and driver.
      * Resends on failure until SUCCESS is received; never sends again after success.
@@ -123,7 +128,7 @@ class BoltConnection implements ConnectionInterface
             return;
         }
 
-        if (isset($this->acknowledgedTelemetryApis[$api->value])) {
+        if (array_key_exists($api->value, $this->acknowledgedTelemetryApis)) {
             return;
         }
 

--- a/src/Bolt/BoltDriver.php
+++ b/src/Bolt/BoltDriver.php
@@ -24,12 +24,23 @@ use Laudis\Neo4j\Common\Uri;
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
 use Laudis\Neo4j\Contracts\DriverInterface;
 use Laudis\Neo4j\Contracts\SessionInterface;
+use Laudis\Neo4j\Databags\Bookmark;
+use Laudis\Neo4j\Databags\BookmarkHolder;
 use Laudis\Neo4j\Databags\DriverConfiguration;
 use Laudis\Neo4j\Databags\ServerInfo;
 use Laudis\Neo4j\Databags\SessionConfiguration;
+use Laudis\Neo4j\Databags\Statement;
+use Laudis\Neo4j\Databags\SummarizedResult;
+use Laudis\Neo4j\Databags\TransactionConfiguration;
+use Laudis\Neo4j\Databags\Neo4jError;
+use Laudis\Neo4j\Enum\AccessMode;
+use Laudis\Neo4j\Enum\BoltTelemetryApi;
+use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
+use Laudis\Neo4j\ParameterHelper;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LogLevel;
+use Throwable;
 
 /**
  * Drives a singular bolt connections.
@@ -118,5 +129,135 @@ final class BoltDriver implements DriverInterface
     public function closeConnections(): void
     {
         $this->pool->close();
+    }
+
+    /**
+     * Runs a Cypher query at driver level (autocommit) and returns an eager result.
+     *
+     * @param array<string, mixed>           $parameters
+     * @param array<string, mixed>|null      $config database, routing (r|w), timeout (seconds), txMeta, impersonatedUser
+     */
+    public function executeQuery(string $cypher, array $parameters = [], ?array $config = null): SummarizedResult
+    {
+        $sessionConfig = SessionConfiguration::fromUri($this->parsedUrl, $this->pool->getLogger());
+        $config ??= [];
+
+        if (array_key_exists('database', $config) && $config['database'] !== null) {
+            $sessionConfig = $sessionConfig->withDatabase($config['database']);
+        }
+
+        $accessMode = AccessMode::READ();
+        if (array_key_exists('routing', $config) && $config['routing'] === 'w') {
+            $accessMode = AccessMode::WRITE();
+        }
+        $sessionConfig = $sessionConfig->withAccessMode($accessMode);
+
+        $tsxConfig = TransactionConfiguration::default();
+        if (array_key_exists('timeout', $config) && $config['timeout'] !== null) {
+            $tsxConfig = $tsxConfig->withTimeout((float) $config['timeout']);
+        }
+
+        $txMeta = $config['txMeta'] ?? null;
+        $maxConnectionAttempts = 3;
+        $connectionAttempt = 0;
+        $lastException = null;
+
+        while ($connectionAttempt < $maxConnectionAttempts) {
+            $connection = GeneratorHelper::getReturnFromGenerator($this->pool->acquire($sessionConfig));
+            $messageFactory = new BoltMessageFactory($connection, $this->pool->getLogger());
+            $transientAttempts = 0;
+
+            try {
+                while ($transientAttempts < $maxConnectionAttempts) {
+                    try {
+                        $connection->sendTelemetryIfNeeded(BoltTelemetryApi::DRIVER_EXECUTE_QUERY);
+
+                        $formattedParameters = ParameterHelper::formatParameters($parameters, $connection->getProtocol())->toArray();
+                        $bookmarkHolder = new BookmarkHolder(Bookmark::from([]));
+
+                        $connection->begin(
+                            $sessionConfig->getDatabase(),
+                            $tsxConfig->getTimeout(),
+                            $bookmarkHolder,
+                            $txMeta,
+                        );
+
+                        $meta = $connection->run(
+                            $cypher,
+                            $formattedParameters,
+                            $sessionConfig->getDatabase(),
+                            $tsxConfig->getTimeout(),
+                            $bookmarkHolder,
+                            $sessionConfig->getAccessMode(),
+                            $txMeta,
+                        );
+
+                        $result = $this->formatter->formatBoltResult(
+                            $meta,
+                            new BoltResult($connection, $sessionConfig->getFetchSize(), $meta['qid'] ?? -1),
+                            $connection,
+                            microtime(true),
+                            0.0,
+                            new Statement($cypher, $parameters),
+                            $bookmarkHolder,
+                        );
+                        $result->preload();
+
+                        $messageFactory->createCommitMessage($bookmarkHolder)->send()->getResponse();
+
+                        return $result;
+                    } catch (Throwable $e) {
+                        $lastException = $e;
+                        if ($this->isTransientExecuteQueryError($e)) {
+                            ++$transientAttempts;
+                            $connection->reset();
+
+                            continue;
+                        }
+
+                        throw $e;
+                    }
+                }
+
+                throw $lastException ?? new Neo4jException([Neo4jError::fromMessageAndCode('Neo.ClientError.General', 'executeQuery failed after transient retries')]);
+            } catch (Throwable $e) {
+                $lastException = $e;
+                ++$connectionAttempt;
+                if (!$this->isConnectionExecuteQueryError($e) || $connectionAttempt >= $maxConnectionAttempts) {
+                    throw $e;
+                }
+                $this->pool->close();
+            } finally {
+                $this->pool->release($connection);
+            }
+        }
+
+        throw $lastException ?? new Neo4jException([Neo4jError::fromMessageAndCode('Neo.ClientError.General', 'executeQuery failed after maximum retries')]);
+    }
+
+    private function isTransientExecuteQueryError(Throwable $e): bool
+    {
+        return $e instanceof Neo4jException && $e->getClassification() === 'TransientError';
+    }
+
+    private function isConnectionExecuteQueryError(Throwable $e): bool
+    {
+        if ($e instanceof ConnectException) {
+            return true;
+        }
+
+        if ($e instanceof Neo4jException) {
+            if ($e->getNeo4jCode() === 'Neo.ClientError.Cluster.NotALeader' || $e->getTitle() === 'NotALeader') {
+                return true;
+            }
+        }
+
+        $message = strtolower($e instanceof Neo4jException ? ($e->getNeo4jMessage() ?? '') : $e->getMessage());
+
+        return str_contains($message, 'broken pipe')
+            || str_contains($message, 'connection reset')
+            || str_contains($message, 'connection closed')
+            || str_contains($message, 'connection refused')
+            || str_contains($message, 'connection timeout');
     }
 }

--- a/src/Bolt/BoltDriver.php
+++ b/src/Bolt/BoltDriver.php
@@ -24,23 +24,12 @@ use Laudis\Neo4j\Common\Uri;
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
 use Laudis\Neo4j\Contracts\DriverInterface;
 use Laudis\Neo4j\Contracts\SessionInterface;
-use Laudis\Neo4j\Databags\Bookmark;
-use Laudis\Neo4j\Databags\BookmarkHolder;
 use Laudis\Neo4j\Databags\DriverConfiguration;
 use Laudis\Neo4j\Databags\ServerInfo;
 use Laudis\Neo4j\Databags\SessionConfiguration;
-use Laudis\Neo4j\Databags\Statement;
-use Laudis\Neo4j\Databags\SummarizedResult;
-use Laudis\Neo4j\Databags\TransactionConfiguration;
-use Laudis\Neo4j\Databags\Neo4jError;
-use Laudis\Neo4j\Enum\AccessMode;
-use Laudis\Neo4j\Enum\BoltTelemetryApi;
-use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
-use Laudis\Neo4j\ParameterHelper;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LogLevel;
-use Throwable;
 
 /**
  * Drives a singular bolt connections.
@@ -129,135 +118,5 @@ final class BoltDriver implements DriverInterface
     public function closeConnections(): void
     {
         $this->pool->close();
-    }
-
-    /**
-     * Runs a Cypher query at driver level (autocommit) and returns an eager result.
-     *
-     * @param array<string, mixed>           $parameters
-     * @param array<string, mixed>|null      $config database, routing (r|w), timeout (seconds), txMeta, impersonatedUser
-     */
-    public function executeQuery(string $cypher, array $parameters = [], ?array $config = null): SummarizedResult
-    {
-        $sessionConfig = SessionConfiguration::fromUri($this->parsedUrl, $this->pool->getLogger());
-        $config ??= [];
-
-        if (array_key_exists('database', $config) && $config['database'] !== null) {
-            $sessionConfig = $sessionConfig->withDatabase($config['database']);
-        }
-
-        $accessMode = AccessMode::READ();
-        if (array_key_exists('routing', $config) && $config['routing'] === 'w') {
-            $accessMode = AccessMode::WRITE();
-        }
-        $sessionConfig = $sessionConfig->withAccessMode($accessMode);
-
-        $tsxConfig = TransactionConfiguration::default();
-        if (array_key_exists('timeout', $config) && $config['timeout'] !== null) {
-            $tsxConfig = $tsxConfig->withTimeout((float) $config['timeout']);
-        }
-
-        $txMeta = $config['txMeta'] ?? null;
-        $maxConnectionAttempts = 3;
-        $connectionAttempt = 0;
-        $lastException = null;
-
-        while ($connectionAttempt < $maxConnectionAttempts) {
-            $connection = GeneratorHelper::getReturnFromGenerator($this->pool->acquire($sessionConfig));
-            $messageFactory = new BoltMessageFactory($connection, $this->pool->getLogger());
-            $transientAttempts = 0;
-
-            try {
-                while ($transientAttempts < $maxConnectionAttempts) {
-                    try {
-                        $connection->sendTelemetryIfNeeded(BoltTelemetryApi::DRIVER_EXECUTE_QUERY);
-
-                        $formattedParameters = ParameterHelper::formatParameters($parameters, $connection->getProtocol())->toArray();
-                        $bookmarkHolder = new BookmarkHolder(Bookmark::from([]));
-
-                        $connection->begin(
-                            $sessionConfig->getDatabase(),
-                            $tsxConfig->getTimeout(),
-                            $bookmarkHolder,
-                            $txMeta,
-                        );
-
-                        $meta = $connection->run(
-                            $cypher,
-                            $formattedParameters,
-                            $sessionConfig->getDatabase(),
-                            $tsxConfig->getTimeout(),
-                            $bookmarkHolder,
-                            $sessionConfig->getAccessMode(),
-                            $txMeta,
-                        );
-
-                        $result = $this->formatter->formatBoltResult(
-                            $meta,
-                            new BoltResult($connection, $sessionConfig->getFetchSize(), $meta['qid'] ?? -1),
-                            $connection,
-                            microtime(true),
-                            0.0,
-                            new Statement($cypher, $parameters),
-                            $bookmarkHolder,
-                        );
-                        $result->preload();
-
-                        $messageFactory->createCommitMessage($bookmarkHolder)->send()->getResponse();
-
-                        return $result;
-                    } catch (Throwable $e) {
-                        $lastException = $e;
-                        if ($this->isTransientExecuteQueryError($e)) {
-                            ++$transientAttempts;
-                            $connection->reset();
-
-                            continue;
-                        }
-
-                        throw $e;
-                    }
-                }
-
-                throw $lastException ?? new Neo4jException([Neo4jError::fromMessageAndCode('Neo.ClientError.General', 'executeQuery failed after transient retries')]);
-            } catch (Throwable $e) {
-                $lastException = $e;
-                ++$connectionAttempt;
-                if (!$this->isConnectionExecuteQueryError($e) || $connectionAttempt >= $maxConnectionAttempts) {
-                    throw $e;
-                }
-                $this->pool->close();
-            } finally {
-                $this->pool->release($connection);
-            }
-        }
-
-        throw $lastException ?? new Neo4jException([Neo4jError::fromMessageAndCode('Neo.ClientError.General', 'executeQuery failed after maximum retries')]);
-    }
-
-    private function isTransientExecuteQueryError(Throwable $e): bool
-    {
-        return $e instanceof Neo4jException && $e->getClassification() === 'TransientError';
-    }
-
-    private function isConnectionExecuteQueryError(Throwable $e): bool
-    {
-        if ($e instanceof ConnectException) {
-            return true;
-        }
-
-        if ($e instanceof Neo4jException) {
-            if ($e->getNeo4jCode() === 'Neo.ClientError.Cluster.NotALeader' || $e->getTitle() === 'NotALeader') {
-                return true;
-            }
-        }
-
-        $message = strtolower($e instanceof Neo4jException ? ($e->getNeo4jMessage() ?? '') : $e->getMessage());
-
-        return str_contains($message, 'broken pipe')
-            || str_contains($message, 'connection reset')
-            || str_contains($message, 'connection closed')
-            || str_contains($message, 'connection refused')
-            || str_contains($message, 'connection timeout');
     }
 }

--- a/src/Bolt/BoltMessageFactory.php
+++ b/src/Bolt/BoltMessageFactory.php
@@ -24,8 +24,10 @@ use Laudis\Neo4j\Bolt\Messages\BoltPullMessage;
 use Laudis\Neo4j\Bolt\Messages\BoltResetMessage;
 use Laudis\Neo4j\Bolt\Messages\BoltRollbackMessage;
 use Laudis\Neo4j\Bolt\Messages\BoltRunMessage;
+use Laudis\Neo4j\Bolt\Messages\BoltTelemetryMessage;
 use Laudis\Neo4j\Common\Neo4jLogger;
 use Laudis\Neo4j\Databags\BookmarkHolder;
+use Laudis\Neo4j\Enum\BoltTelemetryApi;
 
 /**
  * Factory class for creating Bolt protocol messages.
@@ -95,5 +97,10 @@ class BoltMessageFactory
     public function createGoodbyeMessage(): BoltGoodbyeMessage
     {
         return new BoltGoodbyeMessage($this->connection, $this->logger);
+    }
+
+    public function createTelemetryMessage(BoltTelemetryApi $api): BoltTelemetryMessage
+    {
+        return new BoltTelemetryMessage($this->connection, $api, $this->logger);
     }
 }

--- a/src/Bolt/BoltUnmanagedTransaction.php
+++ b/src/Bolt/BoltUnmanagedTransaction.php
@@ -21,6 +21,7 @@ use Laudis\Neo4j\Databags\SessionConfiguration;
 use Laudis\Neo4j\Databags\Statement;
 use Laudis\Neo4j\Databags\SummarizedResult;
 use Laudis\Neo4j\Databags\TransactionConfiguration;
+use Laudis\Neo4j\Enum\BoltTelemetryApi;
 use Laudis\Neo4j\Enum\TransactionState;
 use Laudis\Neo4j\Exception\TransactionException;
 use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
@@ -57,6 +58,7 @@ final class BoltUnmanagedTransaction implements UnmanagedTransactionInterface
         private readonly bool $isInstantTransaction,
         private readonly ?ConnectionPoolInterface $pool = null,
         bool $beginAlreadySent = false,
+        private readonly ?BoltTelemetryApi $beginTelemetryApi = null,
     ) {
         $this->beginSent = $beginAlreadySent;
     }
@@ -153,6 +155,10 @@ final class BoltUnmanagedTransaction implements UnmanagedTransactionInterface
 
         $this->ensureBeginSent();
 
+        if ($this->isInstantTransaction) {
+            $this->connection->sendTelemetryIfNeeded(BoltTelemetryApi::AUTOCOMMIT);
+        }
+
         try {
             $meta = $this->connection->run(
                 $statement->getText(),
@@ -221,6 +227,9 @@ final class BoltUnmanagedTransaction implements UnmanagedTransactionInterface
             return;
         }
         try {
+            if ($this->beginTelemetryApi !== null) {
+                $this->connection->sendTelemetryIfNeeded($this->beginTelemetryApi);
+            }
             $this->connection->begin($this->database, $this->tsxConfig->getTimeout(), $this->bookmarkHolder, $this->tsxConfig->getMetaData());
             $this->beginSent = true;
         } catch (Throwable $e) {

--- a/src/Bolt/ConnectionPool.php
+++ b/src/Bolt/ConnectionPool.php
@@ -61,7 +61,8 @@ final class ConnectionPool implements ConnectionPoolInterface
                 $auth,
                 $conf->getUserAgent(),
                 $conf->getSslConfiguration(),
-                $conf->getSocketTimeoutSecondsExplicit()
+                $conf->getSocketTimeoutSecondsExplicit(),
+                $conf->isTelemetryDisabled(),
             ),
             $conf->getLogger(),
             $conf->getAcquireConnectionTimeout()

--- a/src/Bolt/Messages/BoltTelemetryMessage.php
+++ b/src/Bolt/Messages/BoltTelemetryMessage.php
@@ -20,6 +20,7 @@ use Laudis\Neo4j\Common\Neo4jLogger;
 use Laudis\Neo4j\Contracts\BoltMessage;
 use Laudis\Neo4j\Enum\BoltTelemetryApi;
 use Psr\Log\LogLevel;
+use ReflectionClass;
 use RuntimeException;
 
 final class BoltTelemetryMessage extends BoltMessage
@@ -52,9 +53,8 @@ final class BoltTelemetryMessage extends BoltMessage
      */
     private function discardPipelinedTelemetryResponse(V5_4 $protocol): void
     {
-        $reflection = new \ReflectionClass($protocol);
+        $reflection = new ReflectionClass($protocol);
         $property = $reflection->getProperty('pipelinedMessages');
-        $property->setAccessible(true);
         /** @var list<Message> $pipelined */
         $pipelined = $property->getValue($protocol);
         if ($pipelined !== [] && end($pipelined) === Message::TELEMETRY) {

--- a/src/Bolt/Messages/BoltTelemetryMessage.php
+++ b/src/Bolt/Messages/BoltTelemetryMessage.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Bolt\Messages;
+
+use Bolt\enum\Message;
+use Bolt\protocol\V5_4;
+use Laudis\Neo4j\Bolt\BoltConnection;
+use Laudis\Neo4j\Common\Neo4jLogger;
+use Laudis\Neo4j\Contracts\BoltMessage;
+use Laudis\Neo4j\Enum\BoltTelemetryApi;
+use Psr\Log\LogLevel;
+use RuntimeException;
+
+final class BoltTelemetryMessage extends BoltMessage
+{
+    public function __construct(
+        BoltConnection $connection,
+        private readonly BoltTelemetryApi $api,
+        private readonly ?Neo4jLogger $logger,
+    ) {
+        parent::__construct($connection);
+    }
+
+    public function send(): BoltTelemetryMessage
+    {
+        $protocol = $this->connection->protocol();
+        if (!$protocol instanceof V5_4) {
+            throw new RuntimeException('TELEMETRY requires Bolt protocol 5.4');
+        }
+
+        $this->logger?->log(LogLevel::DEBUG, 'TELEMETRY', ['api' => $this->api->value]);
+        $protocol->telemetry($this->api->value);
+        $this->discardPipelinedTelemetryResponse($protocol);
+
+        return $this;
+    }
+
+    /**
+     * TELEMETRY is sent immediately before BEGIN/RUN; the server may not respond until later.
+     * Do not leave TELEMETRY in the pipelined queue or the next getResponse() will block.
+     */
+    private function discardPipelinedTelemetryResponse(V5_4 $protocol): void
+    {
+        $reflection = new \ReflectionClass($protocol);
+        $property = $reflection->getProperty('pipelinedMessages');
+        $property->setAccessible(true);
+        /** @var list<Message> $pipelined */
+        $pipelined = $property->getValue($protocol);
+        if ($pipelined !== [] && end($pipelined) === Message::TELEMETRY) {
+            array_pop($pipelined);
+            $property->setValue($protocol, $pipelined);
+        }
+    }
+}

--- a/src/Bolt/Session.php
+++ b/src/Bolt/Session.php
@@ -240,38 +240,8 @@ final class Session implements SessionInterface
             || $title === 'NotALeader';
     }
 
-    /**
-     * Execute a statement with automatic retry on connection errors.
-     * Retries up to 3 times on connection failures, clearing routing table between attempts.
-     *
-     * @param Statement                $statement The statement to execute
-     * @param TransactionConfiguration $config    Transaction configuration
-     *
-     * @return SummarizedResult The result of the statement
-     */
-
-    /**
-     * Execute instant transaction (session.run) with automatic retry on connection/routing errors.
-     *
-     * PURPOSE:
-     * - Handles transient failures transparently to user: connection timeouts, server unavailable, etc.
-     * - Supports cluster failover: when server goes down, clears routing table and retries on different node
-     * - Distinguishes errors: retries on connection/routing issues but fails immediately on client errors (syntax, auth)
-     * - Improves reliability: 3 retry attempts with fresh routing table each time = high availability
-     *
-     * EXAMPLE: User calls session.run("CREATE (n)") during cluster failover:
-     *   Attempt 1: Node A is leader → "NotALeader" (stepping down) → Clear routing table
-     *   Attempt 2: Node B elected leader → "Connection timeout" (election in progress) → Retry
-     *   Attempt 3: Cluster stable → Query succeeds
-     *   User sees: Query succeeded transparently (no exception, no manual retry needed)
-     *
-     * WHY THIS IS CRITICAL FOR DRIVERS:
-     * - All Neo4j drivers (Java, Python, JavaScript) have this pattern
-     * - Without it: user must manually retry or wrap every session.run() in try-catch
-     * - With it: driver handles recovery automatically = better UX and reliability
-     */
     private function executeStatementWithRetry(Statement $statement, TransactionConfiguration $config): SummarizedResult
-    {    // Retry instant transactions up to 3 times on connection/routing errors; catch distinguishes retryable errors from client errors (syntax, auth) and clears routing table for cluster failover.
+    {
         $maxRetries = 3;
         $retries = 0;
 
@@ -381,12 +351,23 @@ final class Session implements SessionInterface
     private function startTransaction(TransactionConfiguration $config, SessionConfiguration $sessionConfig): UnmanagedTransactionInterface
     {
         $this->getLogger()?->log(LogLevel::INFO, 'Starting transaction', ['config' => $config, 'sessionConfig' => $sessionConfig]);
-        $connection = $this->acquireConnection($config, $sessionConfig);
 
-        // Defer BEGIN to first run/commit/rollback. The driver does not support OPT_EAGER_TX_BEGIN,
-        // so BEGIN is sent on first run/commit/rollback. This matches test_disconnect_on_tx_begin,
-        // which expects the error at "after run" when the stub disconnects on BEGIN.
+        return $this->buildManagedTransaction(
+            $this->acquireConnection($config, $sessionConfig),
+            $config,
+        );
+    }
 
+    /**
+     * Reuses an existing connection for TestKit managed-transaction retries.
+     */
+    public function openManagedTransactionOnConnection(BoltConnection $connection, ?TransactionConfiguration $config = null): UnmanagedTransactionInterface
+    {
+        return $this->buildManagedTransaction($connection, $this->mergeTsxConfig($config));
+    }
+
+    private function buildManagedTransaction(BoltConnection $connection, TransactionConfiguration $config): UnmanagedTransactionInterface
+    {
         /** @var ConnectionPoolInterface<\Laudis\Neo4j\Contracts\ConnectionInterface>|null $pool */
         $pool = $this->pool;
 
@@ -400,7 +381,7 @@ final class Session implements SessionInterface
             new BoltMessageFactory($connection, $this->getLogger()),
             false,
             $pool,
-            false, // BEGIN sent on first run/commit/rollback
+            false,
             beginTelemetryApi: BoltTelemetryApi::MANAGED_TRANSACTION,
         );
     }
@@ -419,9 +400,6 @@ final class Session implements SessionInterface
         return $tsx;
     }
 
-    /**
-     * Opens a managed-transaction scope (executeRead / executeWrite telemetry) for TestKit retryable handlers.
-     */
     public function openManagedTransaction(?TransactionConfiguration $config = null): UnmanagedTransactionInterface
     {
         $config = $this->mergeTsxConfig($config);

--- a/src/Bolt/Session.php
+++ b/src/Bolt/Session.php
@@ -30,6 +30,7 @@ use Laudis\Neo4j\Databags\Statement;
 use Laudis\Neo4j\Databags\SummarizedResult;
 use Laudis\Neo4j\Databags\TransactionConfiguration;
 use Laudis\Neo4j\Enum\AccessMode;
+use Laudis\Neo4j\Enum\BoltTelemetryApi;
 use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
 use Laudis\Neo4j\Neo4j\Neo4jConnectionPool;
@@ -325,20 +326,6 @@ final class Session implements SessionInterface
     }
 
     /**
-     * @param iterable<Statement> $statements
-     */
-    public function beginTransaction(?iterable $statements = null, ?TransactionConfiguration $config = null): UnmanagedTransactionInterface
-    {
-        $this->getLogger()?->log(LogLevel::INFO, 'Beginning transaction', ['statements' => $statements, 'config' => $config]);
-        $config = $this->mergeTsxConfig($config);
-        $tsx = $this->startTransaction($config, $this->config);
-
-        $tsx->runStatements($statements ?? []);
-
-        return $tsx;
-    }
-
-    /**
      * @return UnmanagedTransactionInterface
      */
     private function beginInstantTransaction(
@@ -361,6 +348,7 @@ final class Session implements SessionInterface
             new BoltMessageFactory($connection, $this->getLogger()),
             true,
             $pool,
+            beginTelemetryApi: null,
         );
     }
 
@@ -413,6 +401,56 @@ final class Session implements SessionInterface
             false,
             $pool,
             false, // BEGIN sent on first run/commit/rollback
+            beginTelemetryApi: BoltTelemetryApi::MANAGED_TRANSACTION,
+        );
+    }
+
+    /**
+     * @param iterable<Statement> $statements
+     */
+    public function beginTransaction(?iterable $statements = null, ?TransactionConfiguration $config = null): UnmanagedTransactionInterface
+    {
+        $this->getLogger()?->log(LogLevel::INFO, 'Beginning transaction', ['statements' => $statements, 'config' => $config]);
+        $config = $this->mergeTsxConfig($config);
+        $tsx = $this->startExplicitTransaction($config, $this->config);
+
+        $tsx->runStatements($statements ?? []);
+
+        return $tsx;
+    }
+
+    /**
+     * Opens a managed-transaction scope (executeRead / executeWrite telemetry) for TestKit retryable handlers.
+     */
+    public function openManagedTransaction(?TransactionConfiguration $config = null): UnmanagedTransactionInterface
+    {
+        $config = $this->mergeTsxConfig($config);
+
+        return $this->startTransaction($config, $this->config);
+    }
+
+    private function startExplicitTransaction(
+        TransactionConfiguration $config,
+        SessionConfiguration $sessionConfig,
+    ): UnmanagedTransactionInterface {
+        $this->getLogger()?->log(LogLevel::INFO, 'Starting explicit transaction', ['config' => $config, 'sessionConfig' => $sessionConfig]);
+        $connection = $this->acquireConnection($config, $sessionConfig);
+
+        /** @var ConnectionPoolInterface<\Laudis\Neo4j\Contracts\ConnectionInterface>|null $pool */
+        $pool = $this->pool;
+
+        return new BoltUnmanagedTransaction(
+            $this->config->getDatabase(),
+            $this->formatter,
+            $connection,
+            $this->config,
+            $config,
+            $this->bookmarkHolder,
+            new BoltMessageFactory($connection, $this->getLogger()),
+            false,
+            $pool,
+            false,
+            BoltTelemetryApi::EXPLICIT_TRANSACTION,
         );
     }
 

--- a/src/BoltFactory.php
+++ b/src/BoltFactory.php
@@ -79,11 +79,24 @@ class BoltFactory
             $sslLevel
         );
 
-        $connection = new BoltConnection($protocol, $connection, $data->getAuth(), $data->getUserAgent(), $config, $this->logger, $socketTimeout);
+        $connection = new BoltConnection(
+            $protocol,
+            $connection,
+            $data->getAuth(),
+            $data->getUserAgent(),
+            $config,
+            $this->logger,
+            $socketTimeout,
+            $data->isTelemetryDisabled(),
+        );
 
         $response = $data->getAuth()->authenticateBolt($connection, $data->getUserAgent());
 
         $config->setServerAgent($response['server'] ?? '');
+
+        if (array_key_exists('hints', $response) && ($response['hints']['telemetry.enabled'] ?? false) === true) {
+            $connection->setServerTelemetryEnabled(true);
+        }
 
         // Timeout precedence: 1) driver config, 2) server hint, 3) default 30s.
         // Only use server hint when driver did not explicitly configure a timeout.

--- a/src/BoltFactory.php
+++ b/src/BoltFactory.php
@@ -94,15 +94,16 @@ class BoltFactory
 
         $config->setServerAgent($response['server'] ?? '');
 
-        if (array_key_exists('hints', $response) && ($response['hints']['telemetry.enabled'] ?? false) === true) {
+        $hints = $response['hints'];
+        if (($hints['telemetry.enabled'] ?? false) === true) {
             $connection->setServerTelemetryEnabled(true);
         }
 
         // Timeout precedence: 1) driver config, 2) server hint, 3) default 30s.
         // Only use server hint when driver did not explicitly configure a timeout.
         $driverHasExplicitTimeout = $data->getSocketTimeoutSeconds() !== null;
-        if (!$driverHasExplicitTimeout && array_key_exists('hints', $response) && array_key_exists('connection.recv_timeout_seconds', $response['hints'])) {
-            $connection->setRecvTimeoutHint((float) $response['hints']['connection.recv_timeout_seconds']);
+        if (!$driverHasExplicitTimeout && array_key_exists('connection.recv_timeout_seconds', $hints)) {
+            $connection->setRecvTimeoutHint((float) $hints['connection.recv_timeout_seconds']);
         }
 
         return $connection;

--- a/src/Common/ExecuteQueryExecutor.php
+++ b/src/Common/ExecuteQueryExecutor.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Common;
+
+use Bolt\error\ConnectException;
+use Laudis\Neo4j\Bolt\BoltConnection;
+use Laudis\Neo4j\Bolt\BoltMessageFactory;
+use Laudis\Neo4j\Bolt\BoltResult;
+use Laudis\Neo4j\Contracts\ConnectionPoolInterface;
+use Laudis\Neo4j\Databags\Bookmark;
+use Laudis\Neo4j\Databags\BookmarkHolder;
+use Laudis\Neo4j\Databags\Neo4jError;
+use Laudis\Neo4j\Databags\SessionConfiguration;
+use Laudis\Neo4j\Databags\Statement;
+use Laudis\Neo4j\Databags\SummarizedResult;
+use Laudis\Neo4j\Databags\TransactionConfiguration;
+use Laudis\Neo4j\Enum\AccessMode;
+use Laudis\Neo4j\Enum\BoltTelemetryApi;
+use Laudis\Neo4j\Exception\Neo4jException;
+use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
+use Laudis\Neo4j\ParameterHelper;
+use Psr\Http\Message\UriInterface;
+use Throwable;
+
+final class ExecuteQueryExecutor
+{
+    private const MAX_ATTEMPTS = 3;
+
+    /**
+     * @param array<string, mixed>                      $parameters
+     * @param array<string, mixed>|null                 $config
+     * @param callable(SessionConfiguration): void|null $onConnectionFailure
+     */
+    public static function run(
+        UriInterface $parsedUrl,
+        ConnectionPoolInterface $pool,
+        SummarizedResultFormatter $formatter,
+        ?Neo4jLogger $logger,
+        string $cypher,
+        array $parameters = [],
+        ?array $config = null,
+        ?callable $onConnectionFailure = null,
+    ): SummarizedResult {
+        $sessionConfig = SessionConfiguration::fromUri($parsedUrl, $logger);
+        $config ??= [];
+
+        if (array_key_exists('database', $config) && is_string($config['database'])) {
+            $sessionConfig = $sessionConfig->withDatabase($config['database']);
+        }
+
+        $accessMode = AccessMode::READ();
+        if (array_key_exists('routing', $config) && $config['routing'] === 'w') {
+            $accessMode = AccessMode::WRITE();
+        }
+        $sessionConfig = $sessionConfig->withAccessMode($accessMode);
+
+        $tsxConfig = TransactionConfiguration::default();
+        if (array_key_exists('timeout', $config) && $config['timeout'] !== null) {
+            $tsxConfig = $tsxConfig->withTimeout((float) $config['timeout']);
+        }
+
+        $txMeta = self::parseTxMeta($config['txMeta'] ?? null);
+        $connectionAttempt = 0;
+        $lastException = null;
+
+        while ($connectionAttempt < self::MAX_ATTEMPTS) {
+            /** @var BoltConnection $connection */
+            $connection = GeneratorHelper::getReturnFromGenerator($pool->acquire($sessionConfig));
+            $messageFactory = new BoltMessageFactory($connection, $logger);
+            $transientAttempts = 0;
+
+            try {
+                while ($transientAttempts < self::MAX_ATTEMPTS) {
+                    try {
+                        $connection->sendTelemetryIfNeeded(BoltTelemetryApi::DRIVER_EXECUTE_QUERY);
+
+                        $formattedParameters = ParameterHelper::formatParameters($parameters, $connection->getProtocol())->toArray();
+                        $bookmarkHolder = new BookmarkHolder(Bookmark::from([]));
+
+                        $connection->begin(
+                            $sessionConfig->getDatabase(),
+                            $tsxConfig->getTimeout(),
+                            $bookmarkHolder,
+                            $txMeta,
+                        );
+
+                        $meta = $connection->run(
+                            $cypher,
+                            $formattedParameters,
+                            $sessionConfig->getDatabase(),
+                            $tsxConfig->getTimeout(),
+                            $bookmarkHolder,
+                            $sessionConfig->getAccessMode(),
+                            $txMeta,
+                        );
+
+                        $result = $formatter->formatBoltResult(
+                            $meta,
+                            new BoltResult($connection, $sessionConfig->getFetchSize(), $meta['qid'] ?? -1),
+                            $connection,
+                            microtime(true),
+                            0.0,
+                            new Statement($cypher, $parameters),
+                            $bookmarkHolder,
+                        );
+                        $result->preload();
+
+                        $messageFactory->createCommitMessage($bookmarkHolder)->send()->getResponse();
+
+                        return $result;
+                    } catch (Throwable $e) {
+                        $lastException = $e;
+                        if ($e instanceof Neo4jException && $e->getClassification() === 'TransientError') {
+                            ++$transientAttempts;
+                            $connection->reset();
+
+                            continue;
+                        }
+
+                        throw $e;
+                    }
+                }
+
+                throw $lastException ?? new Neo4jException([Neo4jError::fromMessageAndCode('Neo.ClientError.General', 'executeQuery failed after transient retries')]);
+            } catch (Throwable $e) {
+                $lastException = $e;
+                ++$connectionAttempt;
+                if (!self::isConnectionError($e) || $connectionAttempt >= self::MAX_ATTEMPTS) {
+                    throw $e;
+                }
+
+                if ($onConnectionFailure !== null) {
+                    $onConnectionFailure($sessionConfig);
+                }
+                $pool->close();
+            } finally {
+                $pool->release($connection);
+            }
+        }
+
+        throw $lastException ?? new Neo4jException([Neo4jError::fromMessageAndCode('Neo.ClientError.General', 'executeQuery failed after maximum retries')]);
+    }
+
+    /**
+     * @return iterable<string, scalar|array|null>|null
+     */
+    private static function parseTxMeta(mixed $txMeta): ?iterable
+    {
+        if (!is_array($txMeta)) {
+            return null;
+        }
+
+        $normalized = [];
+        foreach ($txMeta as $key => $value) {
+            if (!is_string($key) || !self::isSupportedTxMetaValue($value)) {
+                continue;
+            }
+
+            $normalized[$key] = $value;
+        }
+
+        return $normalized === [] ? null : $normalized;
+    }
+
+    /**
+     * @psalm-assert-if-true bool|float|int|string|array|null $value
+     */
+    private static function isSupportedTxMetaValue(mixed $value): bool
+    {
+        return is_scalar($value) || $value === null || is_array($value);
+    }
+
+    private static function isConnectionError(Throwable $e): bool
+    {
+        if ($e instanceof ConnectException) {
+            return true;
+        }
+
+        if ($e instanceof Neo4jException) {
+            if ($e->getNeo4jCode() === 'Neo.ClientError.Cluster.NotALeader' || $e->getTitle() === 'NotALeader') {
+                return true;
+            }
+        }
+
+        $message = strtolower($e instanceof Neo4jException ? ($e->getNeo4jMessage() ?? '') : $e->getMessage());
+
+        return str_contains($message, 'broken pipe')
+            || str_contains($message, 'connection reset')
+            || str_contains($message, 'connection closed')
+            || str_contains($message, 'connection refused')
+            || str_contains($message, 'connection timeout');
+    }
+}

--- a/src/Contracts/AuthenticateInterface.php
+++ b/src/Contracts/AuthenticateInterface.php
@@ -21,7 +21,7 @@ interface AuthenticateInterface
     /**
      * Authenticates a Bolt connection with the provided configuration Uri and userAgent.
      *
-     * @return array{server: string, connection_id: string, hints: list}
+     * @return array{server: string, connection_id: string, hints: array<string, mixed>}
      */
     public function authenticateBolt(BoltConnection $connection, string $userAgent): array;
 

--- a/src/Databags/ConnectionRequestData.php
+++ b/src/Databags/ConnectionRequestData.php
@@ -28,7 +28,13 @@ final class ConnectionRequestData
         private readonly string $userAgent,
         private readonly SslConfiguration $config,
         private readonly ?float $socketTimeoutSeconds = null,
+        private readonly bool $telemetryDisabled = false,
     ) {
+    }
+
+    public function isTelemetryDisabled(): bool
+    {
+        return $this->telemetryDisabled;
     }
 
     public function getHostname(): string

--- a/src/Databags/DriverConfiguration.php
+++ b/src/Databags/DriverConfiguration.php
@@ -67,6 +67,7 @@ final class DriverConfiguration
         ?LoggerInterface $logger,
         ?SocketType $socketType = null,
         private ?float $socketTimeoutSeconds = null,
+        private bool $telemetryDisabled = false,
     ) {
         $this->cache = $cache;
         $this->semaphoreFactory = $semaphore;
@@ -318,6 +319,28 @@ final class DriverConfiguration
     {
         $tbr = clone $this;
         $tbr->socketTimeoutSeconds = $seconds;
+
+        return $tbr;
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function isTelemetryDisabled(): bool
+    {
+        return $this->telemetryDisabled;
+    }
+
+    /**
+     * Opt out of anonymous Bolt API telemetry (Bolt 5.4 TELEMETRY message).
+     * Metrics are collected only when both server and driver have telemetry enabled.
+     *
+     * @psalm-immutable
+     */
+    public function withTelemetryDisabled(bool $disabled = true): self
+    {
+        $tbr = clone $this;
+        $tbr->telemetryDisabled = $disabled;
 
         return $tbr;
     }

--- a/src/Enum/BoltTelemetryApi.php
+++ b/src/Enum/BoltTelemetryApi.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Enum;
+
+/**
+ * Bolt 5.4 TELEMETRY message API identifiers.
+ *
+ * @see https://neo4j.com/docs/bolt/current/bolt/message/#messages-telemetry
+ */
+enum BoltTelemetryApi: int
+{
+    /** Managed transaction (executeRead / executeWrite). */
+    case MANAGED_TRANSACTION = 0;
+    /** Explicit transaction (beginTransaction). */
+    case EXPLICIT_TRANSACTION = 1;
+    /** Autocommit (session.run). */
+    case AUTOCOMMIT = 2;
+    /** Driver-level (executeQuery). */
+    case DRIVER_EXECUTE_QUERY = 3;
+}

--- a/src/Neo4j/Neo4jConnectionPool.php
+++ b/src/Neo4j/Neo4jConnectionPool.php
@@ -97,7 +97,8 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
                 $auth,
                 $conf->getUserAgent(),
                 $conf->getSslConfiguration(),
-                $conf->getSocketTimeoutSecondsExplicit()
+                $conf->getSocketTimeoutSecondsExplicit(),
+                $conf->isTelemetryDisabled(),
             ),
             Cache::getInstance(),
             $resolver,
@@ -114,7 +115,8 @@ final class Neo4jConnectionPool implements ConnectionPoolInterface
             $this->data->getAuth(),
             $this->data->getUserAgent(),
             $this->data->getSslConfig(),
-            $this->data->getSocketTimeoutSeconds()
+            $this->data->getSocketTimeoutSeconds(),
+            $this->data->isTelemetryDisabled(),
         );
 
         $key = $this->createKey($data);

--- a/src/Neo4j/Neo4jDriver.php
+++ b/src/Neo4j/Neo4jDriver.php
@@ -27,25 +27,13 @@ use Laudis\Neo4j\Contracts\AddressResolverInterface;
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
 use Laudis\Neo4j\Contracts\DriverInterface;
 use Laudis\Neo4j\Contracts\SessionInterface;
-use Laudis\Neo4j\Bolt\BoltMessageFactory;
-use Laudis\Neo4j\Bolt\BoltResult;
-use Laudis\Neo4j\Databags\Bookmark;
-use Laudis\Neo4j\Databags\BookmarkHolder;
 use Laudis\Neo4j\Databags\DriverConfiguration;
 use Laudis\Neo4j\Databags\ServerInfo;
 use Laudis\Neo4j\Databags\SessionConfiguration;
-use Laudis\Neo4j\Databags\Statement;
-use Laudis\Neo4j\Databags\Neo4jError;
-use Laudis\Neo4j\Databags\SummarizedResult;
-use Laudis\Neo4j\Databags\TransactionConfiguration;
-use Laudis\Neo4j\Enum\BoltTelemetryApi;
-use Laudis\Neo4j\ParameterHelper;
 use Laudis\Neo4j\Enum\AccessMode;
 use Laudis\Neo4j\Exception\ConnectionPoolException;
-use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
 use Psr\Http\Message\UriInterface;
-use Throwable;
 use Psr\Log\LogLevel;
 
 /**
@@ -135,134 +123,5 @@ final class Neo4jDriver implements DriverInterface
     public function closeConnections(): void
     {
         $this->pool->close();
-    }
-
-    /**
-     * @param array<string, mixed>      $parameters
-     * @param array<string, mixed>|null $config
-     */
-    public function executeQuery(string $cypher, array $parameters = [], ?array $config = null): SummarizedResult
-    {
-        $sessionConfig = SessionConfiguration::fromUri($this->parsedUrl, $this->pool->getLogger());
-        $config ??= [];
-
-        if (array_key_exists('database', $config) && $config['database'] !== null) {
-            $sessionConfig = $sessionConfig->withDatabase($config['database']);
-        }
-
-        $accessMode = AccessMode::READ();
-        if (array_key_exists('routing', $config) && $config['routing'] === 'w') {
-            $accessMode = AccessMode::WRITE();
-        }
-        $sessionConfig = $sessionConfig->withAccessMode($accessMode);
-
-        $tsxConfig = TransactionConfiguration::default();
-        if (array_key_exists('timeout', $config) && $config['timeout'] !== null) {
-            $tsxConfig = $tsxConfig->withTimeout((float) $config['timeout']);
-        }
-
-        $txMeta = $config['txMeta'] ?? null;
-        $maxConnectionAttempts = 3;
-        $connectionAttempt = 0;
-        $lastException = null;
-
-        while ($connectionAttempt < $maxConnectionAttempts) {
-            $connection = GeneratorHelper::getReturnFromGenerator($this->pool->acquire($sessionConfig));
-            $messageFactory = new BoltMessageFactory($connection, $this->pool->getLogger());
-            $transientAttempts = 0;
-
-            try {
-                while ($transientAttempts < $maxConnectionAttempts) {
-                    try {
-                        $connection->sendTelemetryIfNeeded(BoltTelemetryApi::DRIVER_EXECUTE_QUERY);
-
-                        $formattedParameters = ParameterHelper::formatParameters($parameters, $connection->getProtocol())->toArray();
-                        $bookmarkHolder = new BookmarkHolder(Bookmark::from([]));
-
-                        $connection->begin(
-                            $sessionConfig->getDatabase(),
-                            $tsxConfig->getTimeout(),
-                            $bookmarkHolder,
-                            $txMeta,
-                        );
-
-                        $meta = $connection->run(
-                            $cypher,
-                            $formattedParameters,
-                            $sessionConfig->getDatabase(),
-                            $tsxConfig->getTimeout(),
-                            $bookmarkHolder,
-                            $sessionConfig->getAccessMode(),
-                            $txMeta,
-                        );
-
-                        $result = $this->formatter->formatBoltResult(
-                            $meta,
-                            new BoltResult($connection, $sessionConfig->getFetchSize(), $meta['qid'] ?? -1),
-                            $connection,
-                            microtime(true),
-                            0.0,
-                            new Statement($cypher, $parameters),
-                            $bookmarkHolder,
-                        );
-                        $result->preload();
-
-                        $messageFactory->createCommitMessage($bookmarkHolder)->send()->getResponse();
-
-                        return $result;
-                    } catch (Throwable $e) {
-                        $lastException = $e;
-                        if ($this->isTransientExecuteQueryError($e)) {
-                            ++$transientAttempts;
-                            $connection->reset();
-
-                            continue;
-                        }
-
-                        throw $e;
-                    }
-                }
-
-                throw $lastException ?? new Neo4jException([Neo4jError::fromMessageAndCode('Neo.ClientError.General', 'executeQuery failed after transient retries')]);
-            } catch (Throwable $e) {
-                $lastException = $e;
-                ++$connectionAttempt;
-                if (!$this->isConnectionExecuteQueryError($e) || $connectionAttempt >= $maxConnectionAttempts) {
-                    throw $e;
-                }
-                $this->pool->clearRoutingTable($sessionConfig);
-                $this->pool->close();
-            } finally {
-                $this->pool->release($connection);
-            }
-        }
-
-        throw $lastException ?? new Neo4jException([Neo4jError::fromMessageAndCode('Neo.ClientError.General', 'executeQuery failed after maximum retries')]);
-    }
-
-    private function isTransientExecuteQueryError(Throwable $e): bool
-    {
-        return $e instanceof Neo4jException && $e->getClassification() === 'TransientError';
-    }
-
-    private function isConnectionExecuteQueryError(Throwable $e): bool
-    {
-        if ($e instanceof ConnectException) {
-            return true;
-        }
-
-        if ($e instanceof Neo4jException) {
-            if ($e->getNeo4jCode() === 'Neo.ClientError.Cluster.NotALeader' || $e->getTitle() === 'NotALeader') {
-                return true;
-            }
-        }
-
-        $message = strtolower($e instanceof Neo4jException ? ($e->getNeo4jMessage() ?? '') : $e->getMessage());
-
-        return str_contains($message, 'broken pipe')
-            || str_contains($message, 'connection reset')
-            || str_contains($message, 'connection closed')
-            || str_contains($message, 'connection refused')
-            || str_contains($message, 'connection timeout');
     }
 }

--- a/src/Neo4j/Neo4jDriver.php
+++ b/src/Neo4j/Neo4jDriver.php
@@ -27,13 +27,25 @@ use Laudis\Neo4j\Contracts\AddressResolverInterface;
 use Laudis\Neo4j\Contracts\AuthenticateInterface;
 use Laudis\Neo4j\Contracts\DriverInterface;
 use Laudis\Neo4j\Contracts\SessionInterface;
+use Laudis\Neo4j\Bolt\BoltMessageFactory;
+use Laudis\Neo4j\Bolt\BoltResult;
+use Laudis\Neo4j\Databags\Bookmark;
+use Laudis\Neo4j\Databags\BookmarkHolder;
 use Laudis\Neo4j\Databags\DriverConfiguration;
 use Laudis\Neo4j\Databags\ServerInfo;
 use Laudis\Neo4j\Databags\SessionConfiguration;
+use Laudis\Neo4j\Databags\Statement;
+use Laudis\Neo4j\Databags\Neo4jError;
+use Laudis\Neo4j\Databags\SummarizedResult;
+use Laudis\Neo4j\Databags\TransactionConfiguration;
+use Laudis\Neo4j\Enum\BoltTelemetryApi;
+use Laudis\Neo4j\ParameterHelper;
 use Laudis\Neo4j\Enum\AccessMode;
 use Laudis\Neo4j\Exception\ConnectionPoolException;
+use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
 use Psr\Http\Message\UriInterface;
+use Throwable;
 use Psr\Log\LogLevel;
 
 /**
@@ -123,5 +135,134 @@ final class Neo4jDriver implements DriverInterface
     public function closeConnections(): void
     {
         $this->pool->close();
+    }
+
+    /**
+     * @param array<string, mixed>      $parameters
+     * @param array<string, mixed>|null $config
+     */
+    public function executeQuery(string $cypher, array $parameters = [], ?array $config = null): SummarizedResult
+    {
+        $sessionConfig = SessionConfiguration::fromUri($this->parsedUrl, $this->pool->getLogger());
+        $config ??= [];
+
+        if (array_key_exists('database', $config) && $config['database'] !== null) {
+            $sessionConfig = $sessionConfig->withDatabase($config['database']);
+        }
+
+        $accessMode = AccessMode::READ();
+        if (array_key_exists('routing', $config) && $config['routing'] === 'w') {
+            $accessMode = AccessMode::WRITE();
+        }
+        $sessionConfig = $sessionConfig->withAccessMode($accessMode);
+
+        $tsxConfig = TransactionConfiguration::default();
+        if (array_key_exists('timeout', $config) && $config['timeout'] !== null) {
+            $tsxConfig = $tsxConfig->withTimeout((float) $config['timeout']);
+        }
+
+        $txMeta = $config['txMeta'] ?? null;
+        $maxConnectionAttempts = 3;
+        $connectionAttempt = 0;
+        $lastException = null;
+
+        while ($connectionAttempt < $maxConnectionAttempts) {
+            $connection = GeneratorHelper::getReturnFromGenerator($this->pool->acquire($sessionConfig));
+            $messageFactory = new BoltMessageFactory($connection, $this->pool->getLogger());
+            $transientAttempts = 0;
+
+            try {
+                while ($transientAttempts < $maxConnectionAttempts) {
+                    try {
+                        $connection->sendTelemetryIfNeeded(BoltTelemetryApi::DRIVER_EXECUTE_QUERY);
+
+                        $formattedParameters = ParameterHelper::formatParameters($parameters, $connection->getProtocol())->toArray();
+                        $bookmarkHolder = new BookmarkHolder(Bookmark::from([]));
+
+                        $connection->begin(
+                            $sessionConfig->getDatabase(),
+                            $tsxConfig->getTimeout(),
+                            $bookmarkHolder,
+                            $txMeta,
+                        );
+
+                        $meta = $connection->run(
+                            $cypher,
+                            $formattedParameters,
+                            $sessionConfig->getDatabase(),
+                            $tsxConfig->getTimeout(),
+                            $bookmarkHolder,
+                            $sessionConfig->getAccessMode(),
+                            $txMeta,
+                        );
+
+                        $result = $this->formatter->formatBoltResult(
+                            $meta,
+                            new BoltResult($connection, $sessionConfig->getFetchSize(), $meta['qid'] ?? -1),
+                            $connection,
+                            microtime(true),
+                            0.0,
+                            new Statement($cypher, $parameters),
+                            $bookmarkHolder,
+                        );
+                        $result->preload();
+
+                        $messageFactory->createCommitMessage($bookmarkHolder)->send()->getResponse();
+
+                        return $result;
+                    } catch (Throwable $e) {
+                        $lastException = $e;
+                        if ($this->isTransientExecuteQueryError($e)) {
+                            ++$transientAttempts;
+                            $connection->reset();
+
+                            continue;
+                        }
+
+                        throw $e;
+                    }
+                }
+
+                throw $lastException ?? new Neo4jException([Neo4jError::fromMessageAndCode('Neo.ClientError.General', 'executeQuery failed after transient retries')]);
+            } catch (Throwable $e) {
+                $lastException = $e;
+                ++$connectionAttempt;
+                if (!$this->isConnectionExecuteQueryError($e) || $connectionAttempt >= $maxConnectionAttempts) {
+                    throw $e;
+                }
+                $this->pool->clearRoutingTable($sessionConfig);
+                $this->pool->close();
+            } finally {
+                $this->pool->release($connection);
+            }
+        }
+
+        throw $lastException ?? new Neo4jException([Neo4jError::fromMessageAndCode('Neo.ClientError.General', 'executeQuery failed after maximum retries')]);
+    }
+
+    private function isTransientExecuteQueryError(Throwable $e): bool
+    {
+        return $e instanceof Neo4jException && $e->getClassification() === 'TransientError';
+    }
+
+    private function isConnectionExecuteQueryError(Throwable $e): bool
+    {
+        if ($e instanceof ConnectException) {
+            return true;
+        }
+
+        if ($e instanceof Neo4jException) {
+            if ($e->getNeo4jCode() === 'Neo.ClientError.Cluster.NotALeader' || $e->getTitle() === 'NotALeader') {
+                return true;
+            }
+        }
+
+        $message = strtolower($e instanceof Neo4jException ? ($e->getNeo4jMessage() ?? '') : $e->getMessage());
+
+        return str_contains($message, 'broken pipe')
+            || str_contains($message, 'connection reset')
+            || str_contains($message, 'connection closed')
+            || str_contains($message, 'connection refused')
+            || str_contains($message, 'connection timeout');
     }
 }

--- a/testkit-backend/src/Handlers/AbstractRunner.php
+++ b/testkit-backend/src/Handlers/AbstractRunner.php
@@ -113,10 +113,7 @@ abstract class AbstractRunner implements RequestHandlerInterface
                 return new DriverErrorResponse($request->getSessionId(), $wrapped);
             }
             if ($request instanceof TransactionRunRequest) {
-                $response = new DriverErrorResponse($request->getTxId(), $wrapped);
-                $this->repository->addRecords($request->getTxId(), $response);
-
-                return $response;
+                return new DriverErrorResponse($request->getTxId(), $wrapped);
             }
 
             throw new Exception('Unhandled connection exception for run request of type: '.get_class($request));

--- a/testkit-backend/src/Handlers/AbstractRunner.php
+++ b/testkit-backend/src/Handlers/AbstractRunner.php
@@ -113,7 +113,10 @@ abstract class AbstractRunner implements RequestHandlerInterface
                 return new DriverErrorResponse($request->getSessionId(), $wrapped);
             }
             if ($request instanceof TransactionRunRequest) {
-                return new DriverErrorResponse($request->getTxId(), $wrapped);
+                $response = new DriverErrorResponse($request->getTxId(), $wrapped);
+                $this->repository->addRecords($request->getTxId(), $response);
+
+                return $response;
             }
 
             throw new Exception('Unhandled connection exception for run request of type: '.get_class($request));

--- a/testkit-backend/src/Handlers/ExecuteQuery.php
+++ b/testkit-backend/src/Handlers/ExecuteQuery.php
@@ -81,9 +81,9 @@ final class ExecuteQuery implements RequestHandlerInterface
         );
 
         $resultId = Uuid::v4();
-        $this->repository->addEagerResult($resultId, $eagerResult);
+        $this->repository->addRecords($resultId, $eagerResult);
 
-        return new EagerResultResponse($resultId, $eagerResult);
+        return new EagerResultResponse($eagerResult);
     }
 
     private function handleWithSession($driver, ExecuteQueryRequest $request): TestkitResponseInterface
@@ -111,9 +111,9 @@ final class ExecuteQuery implements RequestHandlerInterface
             );
 
             $resultId = Uuid::v4();
-            $this->repository->addEagerResult($resultId, $result);
+            $this->repository->addRecords($resultId, $result);
 
-            return new EagerResultResponse($resultId, $result);
+            return new EagerResultResponse($result);
         } finally {
             $session->close();
         }

--- a/testkit-backend/src/Handlers/NewDriver.php
+++ b/testkit-backend/src/Handlers/NewDriver.php
@@ -51,6 +51,10 @@ final class NewDriver implements RequestHandlerInterface
             $config = $config->withUserAgent($ua);
         }
 
+        if ($request->telemetryDisabled === true) {
+            $config = $config->withTelemetryDisabled(true);
+        }
+
         $authenticate = Authenticate::basic($user, $pass);
         $driver = DriverFactory::create($request->uri, $config, $authenticate);
 

--- a/testkit-backend/src/Handlers/RetryableManagedTransactionSupport.php
+++ b/testkit-backend/src/Handlers/RetryableManagedTransactionSupport.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\TestkitBackend\Handlers;
+
+use Bolt\error\ConnectException as BoltConnectException;
+use Laudis\Neo4j\Bolt\BoltConnection;
+use Laudis\Neo4j\Bolt\BoltMessageFactory;
+use Laudis\Neo4j\Bolt\BoltUnmanagedTransaction;
+use Laudis\Neo4j\Bolt\ConnectionPool;
+use Laudis\Neo4j\Bolt\Session as BoltSession;
+use Laudis\Neo4j\Contracts\UnmanagedTransactionInterface;
+use Laudis\Neo4j\Databags\BookmarkHolder;
+use Laudis\Neo4j\Databags\SessionConfiguration;
+use Laudis\Neo4j\Databags\TransactionConfiguration;
+use Laudis\Neo4j\Enum\BoltTelemetryApi;
+use Laudis\Neo4j\Exception\Neo4jException;
+use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
+use Laudis\Neo4j\Neo4j\Neo4jConnectionPool;
+use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
+use Laudis\Neo4j\TestkitBackend\MainRepository;
+use Laudis\Neo4j\TestkitBackend\Responses\BackendErrorResponse;
+use Laudis\Neo4j\TestkitBackend\Responses\DriverErrorResponse;
+use Laudis\Neo4j\TestkitBackend\Responses\RetryableTryResponse;
+use ReflectionProperty;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * TestKit retryable transactions reuse the same transaction id; replace the underlying managed tx on retry.
+ */
+final class RetryableManagedTransactionSupport
+{
+    private const MAX_RETRIES = 3;
+
+    /** @var array<string, int> */
+    private array $retryAttempts = [];
+
+    public function __construct(
+        private readonly MainRepository $repository,
+    ) {
+    }
+
+    public function clearRetryAttempts(Uuid $sessionId): void
+    {
+        unset($this->retryAttempts[$sessionId->toRfc4122()]);
+    }
+
+    public function isRetryableException(Throwable $exception): bool
+    {
+        if ($exception instanceof BoltConnectException) {
+            return true;
+        }
+
+        if (!$exception instanceof Neo4jException) {
+            return false;
+        }
+
+        if ($exception->getClassification() === 'TransientError') {
+            return true;
+        }
+
+        $code = $exception->getNeo4jCode();
+        if ($code === 'Neo.ClientError.General.ConnectionError') {
+            return true;
+        }
+
+        $message = strtolower($exception->getNeo4jMessage() ?? $exception->getMessage());
+        if (str_contains($message, 'connection')
+            || str_contains($message, 'broken pipe')
+            || str_contains($message, 'connection reset')
+            || str_contains($message, 'connection closed')) {
+            return true;
+        }
+
+        $previous = $exception->getPrevious();
+
+        return $previous !== null && $this->isRetryableException($previous);
+    }
+
+    public function retryManagedTransaction(Uuid $sessionId, Uuid $transactionId, ?DriverErrorResponse $lastError = null): TestkitResponseInterface
+    {
+        $sessionKey = $sessionId->toRfc4122();
+        $this->retryAttempts[$sessionKey] = ($this->retryAttempts[$sessionKey] ?? 0) + 1;
+
+        if ($this->retryAttempts[$sessionKey] > self::MAX_RETRIES) {
+            unset($this->retryAttempts[$sessionKey]);
+            if ($lastError !== null) {
+                return new DriverErrorResponse($transactionId, $lastError->getException());
+            }
+
+            return new BackendErrorResponse('Maximum managed transaction retries exceeded');
+        }
+
+        try {
+            $session = $this->repository->getSession($sessionId);
+        } catch (Throwable $e) {
+            return new BackendErrorResponse('Session not found for retry '.$sessionId->toRfc4122());
+        }
+
+        if (!$session instanceof BoltSession) {
+            return new BackendErrorResponse('Session does not support managed transaction retry');
+        }
+
+        $this->repository->removeRecords($transactionId);
+        $exception = $lastError?->getException();
+        $oldTransaction = $this->repository->getTransaction($transactionId);
+
+        if ($exception instanceof Neo4jException
+            && $exception->getClassification() === 'TransientError'
+            && $oldTransaction instanceof BoltUnmanagedTransaction) {
+            return $this->retryTransientOnSameConnection($session, $transactionId, $oldTransaction);
+        }
+
+        $this->invalidateSessionConnections($session);
+
+        try {
+            $transaction = $session->openManagedTransaction(TransactionConfiguration::default());
+            $this->repository->addTransaction($transactionId, $transaction);
+        } catch (Neo4jException $e) {
+            return new DriverErrorResponse($transactionId, $e);
+        }
+
+        return new RetryableTryResponse($transactionId);
+    }
+
+    private function retryTransientOnSameConnection(
+        BoltSession $session,
+        Uuid $transactionId,
+        BoltUnmanagedTransaction $oldTransaction,
+    ): TestkitResponseInterface {
+        $connection = $this->getTransactionConnection($oldTransaction);
+
+        try {
+            $connection->reset();
+        } catch (Throwable) {
+        }
+
+        try {
+            $transaction = $this->createManagedTransactionOnConnection($session, $connection);
+            $this->repository->addTransaction($transactionId, $transaction);
+        } catch (Neo4jException $e) {
+            return new DriverErrorResponse($transactionId, $e);
+        }
+
+        return new RetryableTryResponse($transactionId);
+    }
+
+    private function createManagedTransactionOnConnection(BoltSession $session, BoltConnection $connection): BoltUnmanagedTransaction
+    {
+        $sessionConfig = $this->getSessionConfiguration($session);
+        $formatter = $this->getSessionFormatter($session);
+        $pool = $this->getSessionPool($session);
+        $bookmarkHolder = $this->getSessionBookmarkHolder($session);
+
+        return new BoltUnmanagedTransaction(
+            $sessionConfig->getDatabase(),
+            $formatter,
+            $connection,
+            $sessionConfig,
+            TransactionConfiguration::default(),
+            $bookmarkHolder,
+            new BoltMessageFactory($connection, $pool->getLogger()),
+            false,
+            $pool,
+            false,
+            BoltTelemetryApi::MANAGED_TRANSACTION,
+        );
+    }
+
+    private function getTransactionConnection(BoltUnmanagedTransaction $transaction): BoltConnection
+    {
+        $property = new ReflectionProperty(BoltUnmanagedTransaction::class, 'connection');
+        $property->setAccessible(true);
+
+        /** @var BoltConnection */
+        return $property->getValue($transaction);
+    }
+
+    private function invalidateSessionConnections(BoltSession $session): void
+    {
+        $pool = $this->getSessionPool($session);
+        $sessionConfig = $this->getSessionConfiguration($session);
+
+        if ($pool instanceof Neo4jConnectionPool) {
+            $pool->clearRoutingTable($sessionConfig);
+        }
+
+        $pool->close();
+    }
+
+    private function getSessionPool(BoltSession $session): ConnectionPool|Neo4jConnectionPool
+    {
+        $property = new ReflectionProperty(BoltSession::class, 'pool');
+        $property->setAccessible(true);
+
+        /** @var ConnectionPool|Neo4jConnectionPool */
+        return $property->getValue($session);
+    }
+
+    private function getSessionConfiguration(BoltSession $session): SessionConfiguration
+    {
+        $property = new ReflectionProperty(BoltSession::class, 'config');
+        $property->setAccessible(true);
+
+        /** @var SessionConfiguration */
+        return $property->getValue($session);
+    }
+
+    private function getSessionFormatter(BoltSession $session): SummarizedResultFormatter
+    {
+        $property = new ReflectionProperty(BoltSession::class, 'formatter');
+        $property->setAccessible(true);
+
+        /** @var SummarizedResultFormatter */
+        return $property->getValue($session);
+    }
+
+    private function getSessionBookmarkHolder(BoltSession $session): BookmarkHolder
+    {
+        $property = new ReflectionProperty(BoltSession::class, 'bookmarkHolder');
+        $property->setAccessible(true);
+
+        /** @var BookmarkHolder */
+        return $property->getValue($session);
+    }
+}

--- a/testkit-backend/src/Handlers/RetryableManagedTransactionSupport.php
+++ b/testkit-backend/src/Handlers/RetryableManagedTransactionSupport.php
@@ -15,17 +15,12 @@ namespace Laudis\Neo4j\TestkitBackend\Handlers;
 
 use Bolt\error\ConnectException as BoltConnectException;
 use Laudis\Neo4j\Bolt\BoltConnection;
-use Laudis\Neo4j\Bolt\BoltMessageFactory;
 use Laudis\Neo4j\Bolt\BoltUnmanagedTransaction;
 use Laudis\Neo4j\Bolt\ConnectionPool;
 use Laudis\Neo4j\Bolt\Session as BoltSession;
-use Laudis\Neo4j\Contracts\UnmanagedTransactionInterface;
-use Laudis\Neo4j\Databags\BookmarkHolder;
 use Laudis\Neo4j\Databags\SessionConfiguration;
 use Laudis\Neo4j\Databags\TransactionConfiguration;
-use Laudis\Neo4j\Enum\BoltTelemetryApi;
 use Laudis\Neo4j\Exception\Neo4jException;
-use Laudis\Neo4j\Formatter\SummarizedResultFormatter;
 use Laudis\Neo4j\Neo4j\Neo4jConnectionPool;
 use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
 use Laudis\Neo4j\TestkitBackend\MainRepository;
@@ -70,8 +65,7 @@ final class RetryableManagedTransactionSupport
             return true;
         }
 
-        $code = $exception->getNeo4jCode();
-        if ($code === 'Neo.ClientError.General.ConnectionError') {
+        if ($exception->getNeo4jCode() === 'Neo.ClientError.General.ConnectionError') {
             return true;
         }
 
@@ -104,7 +98,7 @@ final class RetryableManagedTransactionSupport
 
         try {
             $session = $this->repository->getSession($sessionId);
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             return new BackendErrorResponse('Session not found for retry '.$sessionId->toRfc4122());
         }
 
@@ -147,7 +141,7 @@ final class RetryableManagedTransactionSupport
         }
 
         try {
-            $transaction = $this->createManagedTransactionOnConnection($session, $connection);
+            $transaction = $session->openManagedTransactionOnConnection($connection);
             $this->repository->addTransaction($transactionId, $transaction);
         } catch (Neo4jException $e) {
             return new DriverErrorResponse($transactionId, $e);
@@ -156,32 +150,9 @@ final class RetryableManagedTransactionSupport
         return new RetryableTryResponse($transactionId);
     }
 
-    private function createManagedTransactionOnConnection(BoltSession $session, BoltConnection $connection): BoltUnmanagedTransaction
-    {
-        $sessionConfig = $this->getSessionConfiguration($session);
-        $formatter = $this->getSessionFormatter($session);
-        $pool = $this->getSessionPool($session);
-        $bookmarkHolder = $this->getSessionBookmarkHolder($session);
-
-        return new BoltUnmanagedTransaction(
-            $sessionConfig->getDatabase(),
-            $formatter,
-            $connection,
-            $sessionConfig,
-            TransactionConfiguration::default(),
-            $bookmarkHolder,
-            new BoltMessageFactory($connection, $pool->getLogger()),
-            false,
-            $pool,
-            false,
-            BoltTelemetryApi::MANAGED_TRANSACTION,
-        );
-    }
-
     private function getTransactionConnection(BoltUnmanagedTransaction $transaction): BoltConnection
     {
         $property = new ReflectionProperty(BoltUnmanagedTransaction::class, 'connection');
-        $property->setAccessible(true);
 
         /** @var BoltConnection */
         return $property->getValue($transaction);
@@ -202,7 +173,6 @@ final class RetryableManagedTransactionSupport
     private function getSessionPool(BoltSession $session): ConnectionPool|Neo4jConnectionPool
     {
         $property = new ReflectionProperty(BoltSession::class, 'pool');
-        $property->setAccessible(true);
 
         /** @var ConnectionPool|Neo4jConnectionPool */
         return $property->getValue($session);
@@ -211,27 +181,8 @@ final class RetryableManagedTransactionSupport
     private function getSessionConfiguration(BoltSession $session): SessionConfiguration
     {
         $property = new ReflectionProperty(BoltSession::class, 'config');
-        $property->setAccessible(true);
 
         /** @var SessionConfiguration */
-        return $property->getValue($session);
-    }
-
-    private function getSessionFormatter(BoltSession $session): SummarizedResultFormatter
-    {
-        $property = new ReflectionProperty(BoltSession::class, 'formatter');
-        $property->setAccessible(true);
-
-        /** @var SummarizedResultFormatter */
-        return $property->getValue($session);
-    }
-
-    private function getSessionBookmarkHolder(BoltSession $session): BookmarkHolder
-    {
-        $property = new ReflectionProperty(BoltSession::class, 'bookmarkHolder');
-        $property->setAccessible(true);
-
-        /** @var BookmarkHolder */
         return $property->getValue($session);
     }
 }

--- a/testkit-backend/src/Handlers/RetryableNegative.php
+++ b/testkit-backend/src/Handlers/RetryableNegative.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Laudis\Neo4j\TestkitBackend\Handlers;
 
 use Laudis\Neo4j\Contracts\UnmanagedTransactionInterface;
-use Laudis\Neo4j\Exception\Neo4jException;
 use Laudis\Neo4j\TestkitBackend\Contracts\RequestHandlerInterface;
 use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
 use Laudis\Neo4j\TestkitBackend\MainRepository;
@@ -22,7 +21,6 @@ use Laudis\Neo4j\TestkitBackend\Requests\RetryableNegativeRequest;
 use Laudis\Neo4j\TestkitBackend\Responses\BackendErrorResponse;
 use Laudis\Neo4j\TestkitBackend\Responses\DriverErrorResponse;
 use Laudis\Neo4j\TestkitBackend\Responses\FrontendErrorResponse;
-use Laudis\Neo4j\TestkitBackend\Responses\RetryableTryResponse;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
 use Throwable;
@@ -32,13 +30,10 @@ use Throwable;
  */
 final class RetryableNegative implements RequestHandlerInterface
 {
-    private RetryableManagedTransactionSupport $retrySupport;
-
     public function __construct(
         private readonly MainRepository $repository,
         private readonly LoggerInterface $logger,
     ) {
-        $this->retrySupport = new RetryableManagedTransactionSupport($repository);
     }
 
     /**
@@ -47,6 +42,7 @@ final class RetryableNegative implements RequestHandlerInterface
     public function handle($request): TestkitResponseInterface
     {
         $sessionId = $request->getSessionId();
+        $retrySupport = $this->repository->getRetryableManagedTransactionSupport();
 
         try {
             $transactionId = $this->repository->getTsxIdFromSession($sessionId);
@@ -68,8 +64,8 @@ final class RetryableNegative implements RequestHandlerInterface
 
                 if ($errorResponse instanceof DriverErrorResponse) {
                     $exception = $errorResponse->getException();
-                    if ($this->retrySupport->isRetryableException($exception)) {
-                        return $this->retrySupport->retryManagedTransaction($sessionId, $transactionId, $errorResponse);
+                    if ($retrySupport->isRetryableException($exception)) {
+                        return $retrySupport->retryManagedTransaction($sessionId, $transactionId, $errorResponse);
                     }
 
                     try {

--- a/testkit-backend/src/Handlers/RetryableNegative.php
+++ b/testkit-backend/src/Handlers/RetryableNegative.php
@@ -32,10 +32,13 @@ use Throwable;
  */
 final class RetryableNegative implements RequestHandlerInterface
 {
+    private RetryableManagedTransactionSupport $retrySupport;
+
     public function __construct(
         private readonly MainRepository $repository,
         private readonly LoggerInterface $logger,
     ) {
+        $this->retrySupport = new RetryableManagedTransactionSupport($repository);
     }
 
     /**
@@ -57,13 +60,6 @@ final class RetryableNegative implements RequestHandlerInterface
             return new BackendErrorResponse('Transaction not found '.$transactionId->toRfc4122());
         }
 
-        try {
-            $tsx->rollback();
-        } catch (Throwable $e) {
-            // Best-effort rollback: connection may already be broken. Proceed with error response.
-            $this->logger->debug('Rollback failed during RetryableNegative', ['exception' => $e->getMessage()]);
-        }
-
         $errorId = $request->getErrorId();
         if ($errorId !== '' && $errorId !== null) {
             try {
@@ -72,12 +68,16 @@ final class RetryableNegative implements RequestHandlerInterface
 
                 if ($errorResponse instanceof DriverErrorResponse) {
                     $exception = $errorResponse->getException();
-                    if ($exception instanceof Neo4jException && $exception->getClassification() === 'TransientError') {
-                        // If the original error was retryable, signal for retry
-                        return new RetryableTryResponse($transactionId);
+                    if ($this->retrySupport->isRetryableException($exception)) {
+                        return $this->retrySupport->retryManagedTransaction($sessionId, $transactionId, $errorResponse);
                     }
 
-                    // Otherwise, return the original error to the frontend
+                    try {
+                        $tsx->rollback();
+                    } catch (Throwable $e) {
+                        $this->logger->debug('Rollback failed during RetryableNegative', ['exception' => $e->getMessage()]);
+                    }
+
                     return new DriverErrorResponse($transactionId, $exception);
                 }
             } catch (Throwable $e) {

--- a/testkit-backend/src/Handlers/RetryablePositive.php
+++ b/testkit-backend/src/Handlers/RetryablePositive.php
@@ -30,18 +30,15 @@ use Throwable;
  */
 final class RetryablePositive implements RequestHandlerInterface
 {
-    private MainRepository $repository;
-    private RetryableManagedTransactionSupport $retrySupport;
-
-    public function __construct(MainRepository $repository)
-    {
-        $this->repository = $repository;
-        $this->retrySupport = new RetryableManagedTransactionSupport($repository);
+    public function __construct(
+        private readonly MainRepository $repository,
+    ) {
     }
 
     public function handle($request): TestkitResponseInterface
     {
         $sessionId = $request->getSessionId();
+        $retrySupport = $this->repository->getRetryableManagedTransactionSupport();
 
         try {
             $transactionId = $this->repository->getTsxIdFromSession($sessionId);
@@ -58,13 +55,13 @@ final class RetryablePositive implements RequestHandlerInterface
         try {
             $tsx->commit();
         } catch (Neo4jException|TransactionException $e) {
-            if ($this->retrySupport->isRetryableException($e)) {
+            if ($retrySupport->isRetryableException($e)) {
                 try {
                     $tsx->rollback();
                 } catch (Throwable) {
                 }
 
-                return $this->retrySupport->retryManagedTransaction(
+                return $retrySupport->retryManagedTransaction(
                     $sessionId,
                     $transactionId,
                     new DriverErrorResponse($transactionId, $e),
@@ -74,7 +71,7 @@ final class RetryablePositive implements RequestHandlerInterface
             return new DriverErrorResponse($transactionId, $e);
         }
 
-        $this->retrySupport->clearRetryAttempts($sessionId);
+        $retrySupport->clearRetryAttempts($sessionId);
 
         return new RetryableDoneResponse();
     }

--- a/testkit-backend/src/Handlers/RetryablePositive.php
+++ b/testkit-backend/src/Handlers/RetryablePositive.php
@@ -30,14 +30,13 @@ use Throwable;
  */
 final class RetryablePositive implements RequestHandlerInterface
 {
-    /**
-     * @param RetryablePositiveRequest $request
-     */
     private MainRepository $repository;
+    private RetryableManagedTransactionSupport $retrySupport;
 
     public function __construct(MainRepository $repository)
     {
         $this->repository = $repository;
+        $this->retrySupport = new RetryableManagedTransactionSupport($repository);
     }
 
     public function handle($request): TestkitResponseInterface
@@ -59,8 +58,23 @@ final class RetryablePositive implements RequestHandlerInterface
         try {
             $tsx->commit();
         } catch (Neo4jException|TransactionException $e) {
+            if ($this->retrySupport->isRetryableException($e)) {
+                try {
+                    $tsx->rollback();
+                } catch (Throwable) {
+                }
+
+                return $this->retrySupport->retryManagedTransaction(
+                    $sessionId,
+                    $transactionId,
+                    new DriverErrorResponse($transactionId, $e),
+                );
+            }
+
             return new DriverErrorResponse($transactionId, $e);
         }
+
+        $this->retrySupport->clearRetryAttempts($sessionId);
 
         return new RetryableDoneResponse();
     }

--- a/testkit-backend/src/Handlers/SessionReadTransaction.php
+++ b/testkit-backend/src/Handlers/SessionReadTransaction.php
@@ -61,8 +61,7 @@ final class SessionReadTransaction implements RequestHandlerInterface
 
         $id = Uuid::v4();
         try {
-            // TODO - Create beginReadTransaction and beginWriteTransaction
-            $transaction = $session->beginTransaction(null, $config);
+            $transaction = $session->openManagedTransaction($config);
 
             $this->repository->addTransaction($id, $transaction);
             $this->repository->bindTransactionToSession($request->getSessionId(), $id);

--- a/testkit-backend/src/Handlers/SessionWriteTransaction.php
+++ b/testkit-backend/src/Handlers/SessionWriteTransaction.php
@@ -61,8 +61,7 @@ final class SessionWriteTransaction implements RequestHandlerInterface
 
         $id = Uuid::v4();
         try {
-            // TODO - Create beginReadTransaction and beginWriteTransaction
-            $transaction = $session->beginTransaction(null, $config);
+            $transaction = $session->openManagedTransaction($config);
 
             $this->repository->addTransaction($id, $transaction);
             $this->repository->bindTransactionToSession($request->getSessionId(), $id);

--- a/testkit-backend/src/MainRepository.php
+++ b/testkit-backend/src/MainRepository.php
@@ -19,6 +19,7 @@ use Laudis\Neo4j\Contracts\SessionInterface;
 use Laudis\Neo4j\Contracts\UnmanagedTransactionInterface;
 use Laudis\Neo4j\Databags\SummarizedResult;
 use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
+use Laudis\Neo4j\TestkitBackend\Handlers\RetryableManagedTransactionSupport;
 use Laudis\Neo4j\Types\CypherMap;
 use Symfony\Component\Uid\Uuid;
 
@@ -54,6 +55,8 @@ final class MainRepository
      * @var array<string, int>
      */
     private array $pendingIteratorNextCount = [];
+
+    private ?RetryableManagedTransactionSupport $retryableManagedTransactionSupport = null;
 
     /**
      * @param array<string, DriverInterface<SummarizedResult<CypherMap<OGMTypes>>>>               $drivers
@@ -244,11 +247,8 @@ final class MainRepository
         $this->records[$id] = $records;
     }
 
-    /**
-     * @param SummarizedResult<CypherMap<OGMTypes>> $result
-     */
-    public function addEagerResult(Uuid $id, SummarizedResult $result): void
+    public function getRetryableManagedTransactionSupport(): RetryableManagedTransactionSupport
     {
-        $this->addRecords($id, $result);
+        return $this->retryableManagedTransactionSupport ??= new RetryableManagedTransactionSupport($this);
     }
 }

--- a/testkit-backend/src/MainRepository.php
+++ b/testkit-backend/src/MainRepository.php
@@ -243,4 +243,12 @@ final class MainRepository
     {
         $this->records[$id] = $records;
     }
+
+    /**
+     * @param SummarizedResult<CypherMap<OGMTypes>> $result
+     */
+    public function addEagerResult(Uuid $id, SummarizedResult $result): void
+    {
+        $this->addRecords($id, $result);
+    }
 }

--- a/testkit-backend/src/RequestFactory.php
+++ b/testkit-backend/src/RequestFactory.php
@@ -19,6 +19,7 @@ use Laudis\Neo4j\TestkitBackend\Requests\AuthorizationTokenRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\CheckMultiDBSupportRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\DomainNameResolutionCompletedRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\DriverCloseRequest;
+use Laudis\Neo4j\TestkitBackend\Requests\ExecuteQueryRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\ForcedRoutingTableUpdateRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\GetFeaturesRequest;
 use Laudis\Neo4j\TestkitBackend\Requests\GetRoutingTableRequest;
@@ -60,6 +61,7 @@ final class RequestFactory
         'ResolverResolutionCompleted' => ResolverResolutionCompletedRequest::class,
         'DomainNameResolutionCompleted' => DomainNameResolutionCompletedRequest::class,
         'DriverClose' => DriverCloseRequest::class,
+        'ExecuteQuery' => ExecuteQueryRequest::class,
         'NewSession' => NewSessionRequest::class,
         'SessionClose' => SessionCloseRequest::class,
         'SessionRun' => SessionRunRequest::class,

--- a/testkit-backend/src/Requests/NewDriverRequest.php
+++ b/testkit-backend/src/Requests/NewDriverRequest.php
@@ -41,6 +41,7 @@ final class NewDriverRequest
         public readonly ?int $connectionAcquisitionTimeoutMs = null,
         public readonly mixed $clientCertificate = null,
         public readonly ?string $clientCertificateProviderId = null,
+        public readonly ?bool $telemetryDisabled = null,
     ) {
     }
 }

--- a/testkit-backend/src/Responses/EagerResultResponse.php
+++ b/testkit-backend/src/Responses/EagerResultResponse.php
@@ -15,9 +15,6 @@ namespace Laudis\Neo4j\TestkitBackend\Responses;
 
 use Laudis\Neo4j\Databags\SummarizedResult;
 use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
-use Laudis\Neo4j\TestkitBackend\Responses\Types\CypherObject;
-use stdClass;
-use Symfony\Component\Uid\Uuid;
 use Traversable;
 
 /**
@@ -29,7 +26,7 @@ final class EagerResultResponse implements TestkitResponseInterface
     private array $records;
     private array $summary;
 
-    public function __construct(Uuid $id, SummarizedResult $eagerResult)
+    public function __construct(SummarizedResult $eagerResult)
     {
         $this->keys = $eagerResult->keys();
         $this->summary = (new SummaryResponse($eagerResult))->jsonSerialize()['data'];

--- a/testkit-backend/src/Responses/EagerResultResponse.php
+++ b/testkit-backend/src/Responses/EagerResultResponse.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Laudis\Neo4j\TestkitBackend\Responses;
 
+use Laudis\Neo4j\Databags\SummarizedResult;
 use Laudis\Neo4j\TestkitBackend\Contracts\TestkitResponseInterface;
+use Laudis\Neo4j\TestkitBackend\Responses\Types\CypherObject;
+use stdClass;
 use Symfony\Component\Uid\Uuid;
 use Traversable;
 
@@ -22,15 +25,14 @@ use Traversable;
  */
 final class EagerResultResponse implements TestkitResponseInterface
 {
-    private Uuid $id;
     private array $keys;
     private array $records;
+    private array $summary;
 
-    public function __construct(Uuid $id, $eagerResult)
+    public function __construct(Uuid $id, SummarizedResult $eagerResult)
     {
-        $this->id = $id;
-
-        $this->keys = $eagerResult->getKeys()->toArray();
+        $this->keys = $eagerResult->keys();
+        $this->summary = (new SummaryResponse($eagerResult))->jsonSerialize()['data'];
 
         $this->records = [];
         foreach ($eagerResult as $record) {
@@ -47,9 +49,9 @@ final class EagerResultResponse implements TestkitResponseInterface
         return [
             'name' => 'EagerResult',
             'data' => [
-                'id' => $this->id->toRfc4122(),
                 'keys' => $this->keys,
                 'records' => $this->records,
+                'summary' => $this->summary,
             ],
         ];
     }

--- a/tests/Integration/TelemetryIntegrationTest.php
+++ b/tests/Integration/TelemetryIntegrationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Neo4j PHP Client and Driver package.
+ *
+ * (c) Nagels <https://nagels.tech>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Laudis\Neo4j\Tests\Integration;
+
+use Laudis\Neo4j\Bolt\BoltConnection;
+use Laudis\Neo4j\Bolt\BoltDriver;
+use Laudis\Neo4j\Bolt\ConnectionPool;
+use Laudis\Neo4j\Common\GeneratorHelper;
+use Laudis\Neo4j\Databags\DriverConfiguration;
+use Laudis\Neo4j\Databags\SessionConfiguration;
+use Laudis\Neo4j\Tests\EnvironmentAwareIntegrationTest;
+use ReflectionProperty;
+
+/**
+ * E2E checks against Neo4j Aura (telemetry.enabled hint + driver APIs).
+ */
+final class TelemetryIntegrationTest extends EnvironmentAwareIntegrationTest
+{
+    private function requireAuraConnection(): void
+    {
+        $connection = $_ENV['CONNECTION'] ?? '';
+        if (!is_string($connection) || !str_contains($connection, 'databases.neo4j.io')) {
+            $this->markTestSkipped('Set CONNECTION to a Neo4j Aura URI (e.g. neo4j+s://….databases.neo4j.io) for Aura telemetry E2E.');
+        }
+    }
+
+    public function testAuraAdvertisesTelemetryEnabledHint(): void
+    {
+        $this->requireAuraConnection();
+
+        $driver = BoltDriver::create($this->uri, DriverConfiguration::default());
+        $connection = $this->acquireBoltConnection($driver);
+
+        try {
+            if (!self::readServerTelemetryEnabled($connection)) {
+                $this->markTestSkipped('Server did not advertise telemetry.enabled (expected on Aura when Bolt 5.4 telemetry is enabled).');
+            }
+        } finally {
+            $this->releaseBoltConnection($driver, $connection);
+        }
+    }
+
+    public function testSessionApisWorkWithTelemetryOnAura(): void
+    {
+        $this->requireAuraConnection();
+
+        $session = $this->getSession(['neo4j', 'bolt']);
+
+        self::assertSame(1, $session->run('RETURN 1 AS n')->first()->get('n'));
+
+        $value = $session->readTransaction(static fn ($tsx) => $tsx->run('RETURN 2 AS n')->first()->get('n'));
+        self::assertSame(2, $value);
+
+        $tx = $session->beginTransaction();
+        self::assertSame(3, $tx->run('RETURN 3 AS n')->first()->get('n'));
+        $tx->commit();
+    }
+
+    public function testTelemetryDisabledStillWorksOnAura(): void
+    {
+        $this->requireAuraConnection();
+
+        $driver = BoltDriver::create(
+            $this->uri,
+            DriverConfiguration::default()->withTelemetryDisabled(true),
+        );
+        $session = $driver->createSession();
+        self::assertSame(1, $session->run('RETURN 1 AS n')->first()->get('n'));
+    }
+
+    private function acquireBoltConnection(BoltDriver $driver): BoltConnection
+    {
+        $pool = $this->getPool($driver);
+
+        /** @var BoltConnection */
+        return GeneratorHelper::getReturnFromGenerator($pool->acquire(SessionConfiguration::default()));
+    }
+
+    private function releaseBoltConnection(BoltDriver $driver, BoltConnection $connection): void
+    {
+        $this->getPool($driver)->release($connection);
+    }
+
+    private function getPool(BoltDriver $driver): ConnectionPool
+    {
+        $property = new ReflectionProperty(BoltDriver::class, 'pool');
+
+        /** @var ConnectionPool */
+        return $property->getValue($driver);
+    }
+
+    private static function readServerTelemetryEnabled(BoltConnection $connection): bool
+    {
+        $property = new ReflectionProperty(BoltConnection::class, 'serverTelemetryEnabled');
+
+        return $property->getValue($connection) === true;
+    }
+}

--- a/tests/Integration/TelemetryIntegrationTest.php
+++ b/tests/Integration/TelemetryIntegrationTest.php
@@ -30,7 +30,7 @@ final class TelemetryIntegrationTest extends EnvironmentAwareIntegrationTest
     private function requireAuraConnection(): void
     {
         $connection = $_ENV['CONNECTION'] ?? '';
-        if (!is_string($connection) || !str_contains($connection, 'databases.neo4j.io')) {
+        if ($connection === '' || !str_contains($connection, 'databases.neo4j.io')) {
             $this->markTestSkipped('Set CONNECTION to a Neo4j Aura URI (e.g. neo4j+s://….databases.neo4j.io) for Aura telemetry E2E.');
         }
     }
@@ -43,7 +43,7 @@ final class TelemetryIntegrationTest extends EnvironmentAwareIntegrationTest
         $connection = $this->acquireBoltConnection($driver);
 
         try {
-            if (!self::readServerTelemetryEnabled($connection)) {
+            if (!$connection->isServerTelemetryEnabled()) {
                 $this->markTestSkipped('Server did not advertise telemetry.enabled (expected on Aura when Bolt 5.4 telemetry is enabled).');
             }
         } finally {
@@ -98,12 +98,5 @@ final class TelemetryIntegrationTest extends EnvironmentAwareIntegrationTest
 
         /** @var ConnectionPool */
         return $property->getValue($driver);
-    }
-
-    private static function readServerTelemetryEnabled(BoltConnection $connection): bool
-    {
-        $property = new ReflectionProperty(BoltConnection::class, 'serverTelemetryEnabled');
-
-        return $property->getValue($connection) === true;
     }
 }


### PR DESCRIPTION
- Implemented Bolt 5.4 TELEMETRY for managed transactions, explicit transactions, autocommit (session.run), and driver-level executeQuery, gated by server telemetry.enabled and optional DriverConfiguration::withTelemetryDisabled().
- Added executeQuery on bolt and Neo4j drivers via shared ExecuteQueryExecutor, with transient and connection retry handling.
- Split session transaction paths so managed, explicit, and autocommit APIs report the correct telemetry category.
- Updated the TestKit backend for ExecuteQuery, managed-transaction handlers, retryable tx retry logic, and eager result summaries.
- Added Aura integration tests, README docs, and auth hint normalization (BoltAuthResponse) for Psalm-safe handling of telemetry.enabled.